### PR TITLE
Remove "pause" dialog and extra filters.

### DIFF
--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -21,7 +21,10 @@ div[class*=Grip-module__container] {
 
 /* Add video filters: https://developer.mozilla.org/en-US/docs/Web/CSS/filter */
 #game-stream video {
-    filter: saturate(110%);
+    filter: saturate(110%) contrast(110%) brightness(110%);
+
+    /* Fill xcloud video screen (eg. 4:3 resolutions, or even when running browser in non fullscreen mode) */
+    object-fit: 'fill'; 
 }
 
 /* Hide footer */
@@ -31,6 +34,12 @@ div[class*=Grip-module__container] {
 
 /* Hide splash video (still have sound) */
 video[class*=XboxSplashVideo] {
+    display: none !important;
+}
+
+/* Hide not focused warning dialog */
+
+div[class*=NotFocusedDialog] {
     display: none !important;
 }
 `;


### PR DESCRIPTION
- Added an contrast and brightness filters to enhance
- Fix object fit to `fill` (eg. non 16:9 resolutions or even running xcloud without fullscreen mode)
- Remove pause dialog ("Click here to return to game")