### PR TITLE
Add Kiwi Browser support

### DIFF
--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -1298,10 +1298,22 @@ RTCPeerConnection.prototype.setRemoteDescription = function(...args) {
     const sdpDesc = args[0];
     if (sdpDesc.sdp) {
         const sdp = sdpDesc.sdp;
-        const index = sdp.indexOf('a=fmtp:');
-        if (index > -1) {
-            const line = sdp.substring(index, sdp.indexOf('\n', index));
-            StreamStatus.hqCodec = line.includes('profile-level-id=4d');
+
+        let lineIndex = 0;
+        let endPos = 0;
+        let line;
+        while (lineIndex > -1) {
+            lineIndex = sdp.indexOf('a=fmtp:', endPos);
+            if (lineIndex === -1) {
+                break;
+            }
+
+            endPos = sdp.indexOf('\n', lineIndex);
+            line = sdp.substring(lineIndex, endPos);
+            if (line.includes('profile-level-id')) {
+                StreamStatus.hqCodec = line.includes('profile-level-id=4d');
+                break;
+            }
         }
     }
 

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -83,7 +83,7 @@ class Preferences {
 
         {
             'id': Preferences.USE_DESKTOP_CODEC,
-            'label': 'Force high quality codec',
+            'label': 'Force high quality codec (if possible)',
             'default': false,
         },
 
@@ -1021,7 +1021,7 @@ function patchRtcCodecs() {
     RTCRtpTransceiver.prototype.orgSetCodecPreferences = RTCRtpTransceiver.prototype.setCodecPreferences;
     RTCRtpTransceiver.prototype.setCodecPreferences = function(codecs) {
         // Use the same codecs as desktop
-        codecs = [
+        const newCodecs = [
             {
                 'clockRate': 90000,
                 'mimeType': 'video/H264',
@@ -1033,7 +1033,12 @@ function patchRtcCodecs() {
                 'sdpFmtpLine': 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f',
             }
         ].concat(codecs);
-        this.orgSetCodecPreferences(codecs);
+
+        try {
+            this.orgSetCodecPreferences(newCodecs);
+        } catch (e) {
+            this.orgSetCodecPreferences(codecs);
+        }
     }
 }
 

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -1024,7 +1024,7 @@ function patchRtcCodecs() {
         let profileSetting;
         for (let codec of codecs) {
             if (codec.sdpFmtpLine.includes('profile-level-id=4d') || codec.sdpFmtpLine.includes('profile-level-id=42')) {
-                profileSetting = codec.sdpFmtpLine.substr(-4); // get the last 4 characters
+                profileSetting = codec.sdpFmtpLine.slice(-4); // get the last 4 characters
                 break;
             }
         }
@@ -1293,10 +1293,18 @@ if (document.readyState === 'complete' && !onLoadTriggered) {
 
 RTCPeerConnection.prototype.orgSetRemoteDescription = RTCPeerConnection.prototype.setRemoteDescription;
 RTCPeerConnection.prototype.setRemoteDescription = function(...args) {
+    StreamStatus.hqCodec = false;
+
     const sdpDesc = args[0];
     if (sdpDesc.sdp) {
-        StreamStatus.hqCodec = sdpDesc.sdp.includes('profile-level-id=4d');
+        const sdp = sdpDesc.sdp;
+        const index = sdp.indexOf('a=fmtp:');
+        if (index > -1) {
+            const line = sdp.substring(index, sdp.indexOf('\n', index));
+            StreamStatus.hqCodec = line.includes('profile-level-id=4d');
+        }
     }
+
     return this.orgSetRemoteDescription.apply(this, args);
 }
 

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -1021,18 +1021,31 @@ function patchRtcCodecs() {
     RTCRtpTransceiver.prototype.orgSetCodecPreferences = RTCRtpTransceiver.prototype.setCodecPreferences;
     RTCRtpTransceiver.prototype.setCodecPreferences = function(codecs) {
         // Use the same codecs as desktop
-        const newCodecs = [
-            {
-                'clockRate': 90000,
-                'mimeType': 'video/H264',
-                'sdpFmtpLine': 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f',
-            },
-            {
-                'clockRate': 90000,
-                'mimeType': 'video/H264',
-                'sdpFmtpLine': 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f',
+        let profileSetting;
+        for (let codec of codecs) {
+            if (codec.sdpFmtpLine.includes('profile-level-id=4d') || codec.sdpFmtpLine.includes('profile-level-id=42')) {
+                profileSetting = codec.sdpFmtpLine.substr(-4); // get the last 4 characters
+                break;
             }
-        ].concat(codecs);
+        }
+
+        let newCodecs;
+        if (profileSetting) {
+            newCodecs = [
+                {
+                    'clockRate': 90000,
+                    'mimeType': 'video/H264',
+                    'sdpFmtpLine': 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d' + profileSetting,
+                },
+                {
+                    'clockRate': 90000,
+                    'mimeType': 'video/H264',
+                    'sdpFmtpLine': 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d' + profileSetting,
+                }
+            ].concat(codecs);
+        } else {
+            newCodecs = codecs;
+        }
 
         try {
             this.orgSetCodecPreferences(newCodecs);


### PR DESCRIPTION
- Fix crashes on Kiwi Browser because of unsupported codec profile (#8).  
- Improve codec detection.