### PR TITLE
Add screenshot capture feature

### DIFF
--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -365,7 +365,8 @@ div[class*=StreamMenu-module__menuContainer] > div[class*=Menu-module] {
     border-radius: 0 4px 4px 0;
 }
 
-.better_xcloud_screenshot_btn {
+.better_xcloud_screenshot_button {
+    display: none;
     opacity: 0;
     position: fixed;
     bottom: 0;
@@ -382,11 +383,11 @@ div[class*=StreamMenu-module__menuContainer] > div[class*=Menu-module] {
     z-index: 8888;
 }
 
-.better_xcloud_screenshot_btn[data-showing=true] {
+.better_xcloud_screenshot_button[data-showing=true] {
     opacity: 1;
 }
 
-.better_xcloud_screenshot_btn[data-capturing=true] {
+.better_xcloud_screenshot_button[data-capturing=true] {
     padding: 0px;
 }
 
@@ -1015,6 +1016,7 @@ function patchVideoApi() {
             $SCREENSHOT_CANVAS.width = this.videoWidth;
             $SCREENSHOT_CANVAS.height = this.videoHeight;
             StreamStatus.resolution = {width: this.videoWidth, height: this.videoHeight};
+            document.querySelector('.better_xcloud_screenshot_button').style.display = 'block';
 
             GAME_TITLE_ID = /\/launch\/([^/]+)/.exec(window.location.pathname)[1];
         }
@@ -1257,12 +1259,13 @@ function setupScreenshotButton() {
     const $canvasContext = $SCREENSHOT_CANVAS.getContext('2d');
 
     const delay = 2000;
-    const $btn = createElement('div', {'class': 'better_xcloud_screenshot_btn', 'data-showing': false});
+    const $btn = createElement('div', {'class': 'better_xcloud_screenshot_button', 'data-showing': false});
 
     let timeout;
     const detectDbClick = e => {
         if (!$STREAM_VIDEO) {
             timeout = null;
+            $btn.style.display = 'none';
             return;
         }
 
@@ -1340,6 +1343,9 @@ function hideUiOnPageChange() {
     if ($quickBar) {
         $quickBar.style.display = 'none';
     }
+
+    $STREAM_VIDEO = null;
+    document.querySelector('.better_xcloud_screenshot_button').style = '';
 }
 
 

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -58,6 +58,7 @@ class Preferences {
     static get FORCE_1080P_STREAM() { return 'force_1080p_stream'; }
     static get USE_DESKTOP_CODEC() { return 'use_desktop_codec'; }
 
+    static get SCREENSHOT_BUTTON_POSITION() { return 'screenshot_button_position'; }
     static get BLOCK_TRACKING() { return 'block_tracking'; }
     static get BLOCK_SOCIAL_FEATURES() { return 'block_social_features'; }
     static get DISABLE_BANDWIDTH_CHECKING() { return 'disable_bandwidth_checking'; }
@@ -75,88 +76,71 @@ class Preferences {
             'id': Preferences.SERVER_REGION,
             'label': 'Region of streaming server',
             'default': 'default',
-        },
-
-        {
+        }, {
             'id': Preferences.FORCE_1080P_STREAM,
             'label': 'Force 1080p stream',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.USE_DESKTOP_CODEC,
             'label': 'Force high quality codec (if possible)',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.PREFER_IPV6_SERVER,
             'label': 'Prefer IPv6 streaming server',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.DISABLE_BANDWIDTH_CHECKING,
             'label': 'Disable bandwidth checking',
             'default': false,
-        },
-
-        {
+        }, {
+            'id': Preferences.SCREENSHOT_BUTTON_POSITION,
+            'label': 'Screenshot button\'s position',
+            'default': 'bottom-left',
+            'options': {
+                'bottom-left': 'Bottom Left',
+                'bottom-right': 'Bottom Right',
+                'none': 'Disable',
+            },
+        }, {
             'id': Preferences.SKIP_SPLASH_VIDEO,
             'label': 'Skip Xbox splash video',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.HIDE_DOTS_ICON,
             'label': 'Hide Dots icon while playing',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.REDUCE_ANIMATIONS,
             'label': 'Reduce UI animations',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.BLOCK_SOCIAL_FEATURES,
             'label': 'Disable social features',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.BLOCK_TRACKING,
             'label': 'Disable xCloud analytics',
             'default': false,
-        },
-
-        {
+        }, {
             'id': Preferences.VIDEO_FILL_FULL_SCREEN,
             'label': 'Stretch video to full screen',
             'default': false,
             'hidden': true,
-        },
-
-        {
+        }, {
             'id': Preferences.VIDEO_SATURATION,
             'label': 'Video saturation (%)',
             'default': 100,
             'min': 0,
             'max': 150,
             'hidden': true,
-        },
-
-        {
+        }, {
             'id': Preferences.VIDEO_CONTRAST,
             'label': 'Video contrast (%)',
             'default': 100,
             'min': 0,
             'max': 150,
             'hidden': true,
-        },
-
-        {
+        }, {
             'id': Preferences.VIDEO_BRIGHTNESS,
             'label': 'Video brightness (%)',
             'default': 100,
@@ -370,17 +354,18 @@ div[class*=StreamMenu-module__menuContainer] > div[class*=Menu-module] {
     opacity: 0;
     position: fixed;
     bottom: 0;
-    left: 0;
     width: 60px;
     height: 60px;
     padding: 5px;
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHdpZHRoPSIyNCIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIiBmaWxsPSIjZmZmIj48cGF0aCBkPSJNMTIgN2E1LjAyIDUuMDIgMCAwIDAtNSA1IDUuMDIgNS4wMiAwIDAgMCA1IDUgNS4wMiA1LjAyIDAgMCAwIDUtNSA1LjAyIDUuMDIgMCAwIDAtNS01em0wIDJjMS42NjkgMCAzIDEuMzMxIDMgM3MtMS4zMzEgMy0zIDMtMy0xLjMzMS0zLTMgMS4zMzEtMyAzLTN6TTYgMkMzLjgwMSAyIDIgMy44MDEgMiA2djJhMSAxIDAgMSAwIDIgMFY2YTEuOTcgMS45NyAwIDAgMSAyLTJoMmExIDEgMCAxIDAgMC0yek0zIDE1YTEgMSAwIDAgMC0xIDF2MmMwIDIuMTk5IDEuODAxIDQgNCA0aDJhMSAxIDAgMSAwIDAtMkg2YTEuOTcgMS45NyAwIDAgMS0yLTJ2LTJhMSAxIDAgMCAwLTEtMXptMTggMGExIDEgMCAwIDAtMSAxdjJhMS45NyAxLjk3IDAgMCAxLTIgMmgtMmExIDEgMCAxIDAgMCAyaDJjMi4xOTkgMCA0LTEuODAxIDQtNHYtMmExIDEgMCAwIDAtMS0xeiIvPjxwYXRoIGQ9Ik0xNiAyYTEgMSAwIDEgMCAwIDJoMmExLjk3IDEuOTcgMCAwIDEgMiAydjJhMSAxIDAgMSAwIDIgMFY2YzAtMi4xOTktMS44MDEtNC00LTR6Ii8+PC9zdmc+Cg==);
     background-size: cover;
     background-repeat: no-repeat;
     background-origin: content-box;
     filter: drop-shadow(0 0 2px #000000B0);
     transition: opacity 0.1s ease-in-out 0s, padding 0.1s ease-in 0s;
     z-index: 8888;
+
+    /* Credit: https://www.iconfinder.com/iconsets/user-interface-outline-27 */
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHdpZHRoPSIyNCIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIiBmaWxsPSIjZmZmIj48cGF0aCBkPSJNMTIgN2E1LjAyIDUuMDIgMCAwIDAtNSA1IDUuMDIgNS4wMiAwIDAgMCA1IDUgNS4wMiA1LjAyIDAgMCAwIDUtNSA1LjAyIDUuMDIgMCAwIDAtNS01em0wIDJjMS42NjkgMCAzIDEuMzMxIDMgM3MtMS4zMzEgMy0zIDMtMy0xLjMzMS0zLTMgMS4zMzEtMyAzLTN6TTYgMkMzLjgwMSAyIDIgMy44MDEgMiA2djJhMSAxIDAgMSAwIDIgMFY2YTEuOTcgMS45NyAwIDAgMSAyLTJoMmExIDEgMCAxIDAgMC0yek0zIDE1YTEgMSAwIDAgMC0xIDF2MmMwIDIuMTk5IDEuODAxIDQgNCA0aDJhMSAxIDAgMSAwIDAtMkg2YTEuOTcgMS45NyAwIDAgMS0yLTJ2LTJhMSAxIDAgMCAwLTEtMXptMTggMGExIDEgMCAwIDAtMSAxdjJhMS45NyAxLjk3IDAgMCAxLTIgMmgtMmExIDEgMCAxIDAgMCAyaDJjMi4xOTkgMCA0LTEuODAxIDQtNHYtMmExIDEgMCAwIDAtMS0xeiIvPjxwYXRoIGQ9Ik0xNiAyYTEgMSAwIDEgMCAwIDJoMmExLjk3IDEuOTcgMCAwIDEgMiAydjJhMSAxIDAgMSAwIDIgMFY2YzAtMi4xOTktMS44MDEtNC00LTR6Ii8+PC9zdmc+Cg==);
 }
 
 .better_xcloud_screenshot_button[data-showing=true] {
@@ -752,27 +737,41 @@ function injectSettingsButton($parent) {
 
         let $control;
         let labelAttrs = {};
-        if (setting.id === Preferences.SERVER_REGION) {
+        if (setting.id === Preferences.SERVER_REGION || setting.options) {
+            let selectedValue;
+
             $control = CE('select', {id: 'xcloud_setting_' + setting.id});
             $control.addEventListener('change', e => {
-                PREFS.set(Preferences.SERVER_REGION, e.target.value);
+                PREFS.set(setting.id, e.target.value);
             });
 
-            for (let regionName in SERVER_REGIONS) {
-                const region = SERVER_REGIONS[regionName];
-                let value = regionName;
+            if (setting.id === Preferences.SERVER_REGION) {
+                selectedValue = preferredRegion;
+                setting.options = {};
+                for (let regionName in SERVER_REGIONS) {
+                    const region = SERVER_REGIONS[regionName];
+                    let value = regionName;
 
-                let label = regionName;
-                if (region.isDefault) {
-                    label += ' (Default)';
-                    value = 'default';
+                    let label = regionName;
+                    if (region.isDefault) {
+                        label += ' (Default)';
+                        value = 'default';
+                    }
+
+                    setting.options[value] = label;
                 }
+            } else {
+                selectedValue = PREFS.get(setting.id);
+            }
+
+            for (let value in setting.options) {
+                const label = setting.options[value];
 
                 const $option = CE('option', {value: value}, label);
-                $option.selected = regionName === preferredRegion;
-
+                $option.selected = value === selectedValue || label.includes(selectedValue);
                 $control.appendChild($option);
             }
+
         } else {
             $control = CE('input', {
                 id: 'xcloud_setting_' + setting.id,
@@ -1004,6 +1003,7 @@ function injectVideoSettingsButton() {
 
 function patchVideoApi() {
     const PREF_SKIP_SPLASH_VIDEO = PREFS.get(Preferences.SKIP_SPLASH_VIDEO);
+    const PREF_SCREENSHOT_BUTTON_POSITION = PREFS.get(Preferences.SCREENSHOT_BUTTON_POSITION);
 
     // Show video player when it's ready
     var showFunc;
@@ -1016,7 +1016,17 @@ function patchVideoApi() {
             $SCREENSHOT_CANVAS.width = this.videoWidth;
             $SCREENSHOT_CANVAS.height = this.videoHeight;
             StreamStatus.resolution = {width: this.videoWidth, height: this.videoHeight};
-            document.querySelector('.better_xcloud_screenshot_button').style.display = 'block';
+
+            if (PREF_SCREENSHOT_BUTTON_POSITION !== 'none') {
+                const $btn = document.querySelector('.better_xcloud_screenshot_button');
+                $btn.style.display = 'block';
+
+                if (PREF_SCREENSHOT_BUTTON_POSITION === 'bottom-right') {
+                    $btn.style.right = '0';
+                } else {
+                    $btn.style.left = '0';
+                }
+            }
 
             GAME_TITLE_ID = /\/launch\/([^/]+)/.exec(window.location.pathname)[1];
         }


### PR DESCRIPTION
Closes #12  

Capture screenshot by pressing on the button at the bottom left/right of the screen while playing.  

This button is hidden by default.  
Tap once to show the button, tap again to capture screenshot.  
Screenshot will be saved by browser.  

![image](https://github.com/redphx/better-xcloud/assets/96280/2dabc1ce-6130-41e6-9d2a-7a2bc7748583)