### PR TITLE
Show stream stats

### DIFF
--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -498,6 +498,12 @@ div[class*=NotFocusedDialog] {
 #game-stream video {
     visibility: hidden;
 }
+
+/* Adjust Stream menu icon's size */
+button[class*=MenuItem-module__container] {
+    min-width: auto !important;
+    width: 110px !important;
+}
 `;
 
     // Reduce animations

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -140,7 +140,8 @@ class StreamStats {
                     StreamStats.#lastInbound = stat;
                 } else if (stat.type === 'candidate-pair' && stat.state === 'succeeded') {
                     // Round Trip Time
-                    StreamStats.#$rtt.textContent = `${stat.currentRoundTripTime * 1000}ms`;
+                    const roundTripTime = typeof stat.currentRoundTripTime !== 'undefined' ? stat.currentRoundTripTime * 1000 : '???';
+                    StreamStats.#$rtt.textContent = `${roundTripTime}ms`;
                 }
             });
 

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -699,7 +699,6 @@ function interceptHttpRequests() {
     const PREF_PREFER_IPV6_SERVER = PREFS.get(Preferences.PREFER_IPV6_SERVER);
     const PREF_FORCE_1080P_STREAM = PREFS.get(Preferences.FORCE_1080P_STREAM);
     const PREF_USE_DESKTOP_CODEC = PREFS.get(Preferences.USE_DESKTOP_CODEC);
-    const HAS_CODECS_API_SUPPORT = hasRtcSetCodecPreferencesSupport();
 
     const orgFetch = window.fetch;
     window.fetch = async (...arg) => {
@@ -768,27 +767,6 @@ function interceptHttpRequests() {
             }
 
             return orgFetch(...arg);
-        }
-
-        // Work-around for browsers with no setCodecPreferences() support
-        if (PREF_USE_DESKTOP_CODEC && !HAS_CODECS_API_SUPPORT && url.endsWith('/sdp') && url.includes('/sessions/cloud/') && request.method === 'GET') {
-            const promise = orgFetch(...arg);
-
-            return promise.then(response => {
-                return response.clone().text().then(text => {
-                    if (!text.length) {
-                        return response;
-                    }
-
-                    const obj = JSON.parse(text);
-                    obj.exchangeResponse = obj.exchangeResponse.replaceAll('profile-level-id=42', 'profile-level-id=4d');
-
-                    response.json = () => Promise.resolve(obj);
-                    response.text = () => Promise.resolve(JSON.stringify(obj));
-
-                    return response;
-                });
-            });
         }
 
         // ICE server candidates

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -405,6 +405,8 @@ div[class*=StreamMenu-module__menuContainer] > div[class*=Menu-module] {
     font-family: Bahnschrift Semibold, Arial, Helvetica, sans-serif;
     font-weight: 400;
     margin: 0 8px 8px 0;
+    box-shadow: 0px 0px 6px #000;
+    border-radius: 4px;
 }
 
 .better_xcloud_badge .better_xcloud_badge_name {

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -923,6 +923,13 @@ function injectSettingsButton($parent) {
             $control.checked = setting.value;
 
             labelAttrs = {'for': 'xcloud_setting_' + setting.id, 'tabindex': 0};
+
+            if (setting.id === Preferences.USE_DESKTOP_CODEC && !hasRtcSetCodecPreferencesSupport()) {
+                $control.checked = false;
+                $control.disabled = true;
+                $control.title = 'Your browser doesn\'t support this feature';
+                $control.style.cursor = 'help';
+            }
         }
 
         const $elm = CE('div', {'class': 'setting_row'},

--- a/better-xcloud.user.js
+++ b/better-xcloud.user.js
@@ -917,10 +917,6 @@ function injectSettingsButton($parent) {
 
             $control.addEventListener('change', e => {
                 PREFS.set(e.target.getAttribute('data-key'), e.target.checked);
-
-                if (setting.id == Preferences.VIDEO_FILL_FULL_SCREEN) {
-                    updateVideoPlayerPreview();
-                }
             });
 
             setting.value = PREFS.get(setting.id);
@@ -989,24 +985,6 @@ function updateVideoPlayerCss() {
     }
 
     $elm.textContent = css;
-}
-
-
-function updateVideoPlayerPreview() {
-    const $screen = document.querySelector('.better_xcloud_settings_preview_screen');
-    $screen.style.display = 'block';
-
-    const filters = getVideoPlayerFilterStyle();
-    const $video = document.querySelector('.better_xcloud_settings_preview_video');
-    $video.style.filter = filters;
-
-    if (PREFS.get(Preferences.VIDEO_FILL_FULL_SCREEN)) {
-        $video.style.height = 'auto';
-    } else {
-        $video.style.height = '100%';
-    }
-
-    updateVideoPlayerCss();
 }
 
 


### PR DESCRIPTION
Closes #6  

![image](https://github.com/redphx/better-xcloud/assets/96280/045c59d3-c0e8-4e1d-8c13-dce20540e760)

- Show video & audio codecs.  
- Show Stream stats: FPS, round trip time, bitrate, packets lost, frames lost.  
- Disable `Force high quality codec` feature on unsupported browsers.  