### PR TITLE
[Submit layout] "Plateup!", "Roboquest" and Adjust gyroscope sensitivity in Halo Infinite.

### DIFF
--- a/touch-layouts/1922695178.json
+++ b/touch-layouts/1922695178.json
@@ -1,0 +1,7 @@
+{
+	"name": "PlateUp!",
+	"default_layout": "custom",
+	"layouts": [
+		"plateup"
+	]
+}

--- a/touch-layouts/1953745880.json
+++ b/touch-layouts/1953745880.json
@@ -1,0 +1,7 @@
+{
+	"name": "Roboquest",
+	"default_layout": "custom",
+	"layouts": [
+		"roboquest"
+	]
+}

--- a/touch-layouts/layouts/halo-infinite.json
+++ b/touch-layouts/layouts/halo-infinite.json
@@ -7,13 +7,16 @@
         "layers": {
           "AimTouchpad": {
             "right": {
-              "inner": [{
+              "inner": [
+                {
                   "type": "touchpad",
-                  "axis": [{
+                  "axis": [
+                    {
                       "input": "axisX",
                       "output": "rightJoystickX",
                       "sensitivity": 3
-                    }, {
+                    },
+                    {
                       "input": "axisY",
                       "output": "rightJoystickY",
                       "sensitivity": 3
@@ -30,19 +33,28 @@
                 }
               ]
             },
-            "sensors": [{
+            "sensors": [
+              {
                 "type": "gyroscope",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "rightJoystick",
-                  "sensitivity": 2
-                }
+                "axis": [
+                  {
+                    "input": "axisX",
+                    "output": "rightJoystickX",
+                    "sensitivity": 1
+                  },
+                  {
+                    "input": "axisY",
+                    "output": "rightJoystickY",
+                    "sensitivity": 0.5
+                  }
+                ]
               }
             ]
           }
         },
         "left": {
-          "inner": [{
+          "inner": [
+            {
               "type": "joystick",
               "axis": {
                 "input": "axisXY",
@@ -68,7 +80,8 @@
           "outer": [
             null,
             null,
-            [{
+            [
+              {
                 "type": "directionalPad",
                 "interaction": {
                   "activationType": "exclusive"
@@ -77,7 +90,8 @@
               }
             ],
             null,
-            null, {
+            null,
+            {
               "type": "joystick",
               "axis": {
                 "input": "axisXY",
@@ -88,7 +102,8 @@
                 }
               },
               "action": [
-                "leftTrigger", {
+                "leftTrigger",
+                {
                   "type": "layer",
                   "target": "AimTouchpad"
                 }
@@ -110,7 +125,8 @@
           ]
         },
         "right": {
-          "inner": [{
+          "inner": [
+            {
               "type": "joystick",
               "axis": {
                 "input": "axisXY",
@@ -132,13 +148,16 @@
               }
             }
           ],
-          "outer": [{
+          "outer": [
+            {
               "type": "button",
               "action": "rightBumper"
-            }, {
+            },
+            {
               "type": "button",
               "action": [
-                "leftTrigger", {
+                "leftTrigger",
+                {
                   "type": "layer",
                   "target": "AimTouchpad"
                 }
@@ -153,13 +172,16 @@
               },
               "toggle": true
             },
-            [{
+            [
+              {
                 "type": "button",
                 "action": "gamepadB"
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "rightThumb"
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "gamepadA",
                 "styles": {
@@ -172,13 +194,16 @@
                 }
               }
             ],
-            [{
+            [
+              {
                 "type": "touchpad",
-                "axis": [{
+                "axis": [
+                  {
                     "input": "axisX",
                     "output": "rightJoystickX",
                     "sensitivity": 3
-                  }, {
+                  },
+                  {
                     "input": "axisY",
                     "output": "rightJoystickY",
                     "sensitivity": 3
@@ -194,7 +219,8 @@
                     }
                   }
                 }
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "leftThumb",
                 "styles": {
@@ -205,11 +231,13 @@
                     }
                   }
                 }
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "leftBumper"
               }
-            ], {
+            ],
+            {
               "type": "button",
               "action": "gamepadX",
               "styles": {
@@ -220,7 +248,8 @@
                   }
                 }
               }
-            }, {
+            },
+            {
               "type": "button",
               "action": "gamepadY",
               "styles": {
@@ -235,10 +264,12 @@
           ]
         },
         "upper": {
-          "right": [{
+          "right": [
+            {
               "type": "button",
               "action": "menu"
-            }, {
+            },
+            {
               "type": "button",
               "action": "view"
             }
@@ -251,19 +282,28 @@
       "content": {
         "layers": {
           "AimTouchpad": {
-            "sensors": [{
+            "sensors": [
+              {
                 "type": "gyroscope",
-                "axis": {
-                  "input": "axisXY",
-                  "output": "relativeMouse",
-                  "sensitivity": 10
-                }
+                "axis": [
+                  {
+                    "input": "axisX",
+                    "output": "relativeMouseX",
+                    "sensitivity": 10
+                  },
+                  {
+                    "input": "axisY",
+                    "output": "relativeMouse",
+                    "sensitivity": 5
+                  }
+                ]
               }
             ]
           }
         },
         "left": {
-          "inner": [{
+          "inner": [
+            {
               "type": "joystick",
               "axis": {
                 "input": "axisXY",
@@ -289,7 +329,8 @@
           "outer": [
             null,
             null,
-            [{
+            [
+              {
                 "type": "directionalPad",
                 "interaction": {
                   "activationType": "exclusive"
@@ -298,7 +339,8 @@
               }
             ],
             null,
-            null, {
+            null,
+            {
               "type": "joystick",
               "axis": {
                 "input": "axisXY",
@@ -309,7 +351,8 @@
                 }
               },
               "action": [
-                "leftTrigger", {
+                "leftTrigger",
+                {
                   "type": "layer",
                   "target": "AimTouchpad"
                 }
@@ -331,13 +374,16 @@
           ]
         },
         "right": {
-          "inner": [{
+          "inner": [
+            {
               "type": "touchpad",
-              "axis": [{
+              "axis": [
+                {
                   "input": "axisX",
                   "output": "relativeMouseX",
                   "sensitivity": 10
-                }, {
+                },
+                {
                   "input": "axisY",
                   "output": "relativeMouseY",
                   "sensitivity": 10
@@ -353,13 +399,16 @@
               }
             }
           ],
-          "outer": [{
+          "outer": [
+            {
               "type": "button",
               "action": "rightBumper"
-            }, {
+            },
+            {
               "type": "button",
               "action": [
-                "leftTrigger", {
+                "leftTrigger",
+                {
                   "type": "layer",
                   "target": "AimTouchpad"
                 }
@@ -374,13 +423,16 @@
               },
               "toggle": true
             },
-            [{
+            [
+              {
                 "type": "button",
                 "action": "gamepadB"
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "rightThumb"
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "gamepadA",
                 "styles": {
@@ -393,13 +445,16 @@
                 }
               }
             ],
-            [{
+            [
+              {
                 "type": "touchpad",
-                "axis": [{
+                "axis": [
+                  {
                     "input": "axisX",
                     "output": "relativeMouseX",
                     "sensitivity": 10
-                  }, {
+                  },
+                  {
                     "input": "axisY",
                     "output": "relativeMouseY",
                     "sensitivity": 10
@@ -407,7 +462,8 @@
                 ],
                 "renderAsButton": true,
                 "action": [
-                  "rightTrigger", {
+                  "rightTrigger",
+                  {
                     "type": "layer",
                     "target": "AimTouchpad"
                   }
@@ -420,7 +476,8 @@
                     }
                   }
                 }
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "leftThumb",
                 "styles": {
@@ -431,11 +488,13 @@
                     }
                   }
                 }
-              }, {
+              },
+              {
                 "type": "button",
                 "action": "leftBumper"
               }
-            ], {
+            ],
+            {
               "type": "button",
               "action": "gamepadX",
               "styles": {
@@ -446,7 +505,8 @@
                   }
                 }
               }
-            }, {
+            },
+            {
               "type": "button",
               "action": "gamepadY",
               "styles": {
@@ -461,10 +521,12 @@
           ]
         },
         "upper": {
-          "right": [{
+          "right": [
+            {
               "type": "button",
               "action": "menu"
-            }, {
+            },
+            {
               "type": "button",
               "action": "view"
             }

--- a/touch-layouts/layouts/plateup.json
+++ b/touch-layouts/layouts/plateup.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Custom",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "expand": false,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            [
+              {
+                "type": "directionalPad",
+                "scale": 1.2
+              }
+            ]
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "button",
+              "action": "gamepadA"
+            }
+          ],
+          "outer": [
+            null,
+            {
+              "type": "button",
+              "action": "gamepadB",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "waypoint"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "leftBumper"
+            },
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
+            null,
+            [
+              {
+                "type": "button",
+                "action": "gamepadY",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "accept"
+                    }
+                  }
+                }
+              },
+              null
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/touch-layouts/layouts/roboquest.json
+++ b/touch-layouts/layouts/roboquest.json
@@ -1,0 +1,289 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Custom",
+      "content": {
+        "layers": {
+          "AimTouchpad": {
+            "right": {
+              "inner": [
+                {
+                  "type": "touchpad",
+                  "axis": [
+                    {
+                      "input": "axisX",
+                      "output": "rightJoystickX",
+                      "sensitivity": 3
+                    },
+                    {
+                      "input": "axisY",
+                      "output": "rightJoystickY",
+                      "sensitivity": 3
+                    }
+                  ],
+                  "styles": {
+                    "default": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "aim"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "sensors": [
+              {
+                "type": "gyroscope",
+                "axis": [
+                  {
+                    "input": "axisX",
+                    "output": "rightJoystickX",
+                    "sensitivity": 1
+                  },
+                  {
+                    "input": "axisY",
+                    "output": "rightJoystickY",
+                    "sensitivity": 0.5
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.01,
+                  "radial": true
+                }
+              },
+              "expand": false,
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "walk"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            [
+              {
+                "type": "directionalPad",
+                "interaction": {
+                  "activationType": "exclusive"
+                },
+                "scale": 1.2
+              }
+            ],
+            null,
+            null,
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0,
+                  "radial": true
+                }
+              },
+              "action": [
+                "leftTrigger",
+                {
+                  "type": "layer",
+                  "target": "AimTouchpad"
+                }
+              ],
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "leftTrigger"
+                    },
+                    "stroke": {
+                      "opacity": 0.1
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick",
+                "deadzone": {
+                  "threshold": 0.01,
+                  "radial": true
+                }
+              },
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "look"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            {
+              "type": "button",
+              "action": "rightBumper"
+            },
+            {
+              "type": "button",
+              "action": [
+                "leftTrigger",
+                {
+                  "type": "layer",
+                  "target": "AimTouchpad"
+                }
+              ],
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "leftTrigger"
+                  }
+                }
+              },
+              "toggle": true
+            },
+            [
+              {
+                "type": "button",
+                "action": "gamepadB",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "crouch"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "action": "rightThumb"
+              },
+              {
+                "type": "button",
+                "action": "gamepadA",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "jump"
+                    }
+                  }
+                }
+              }
+            ],
+            [
+              {
+                "type": "touchpad",
+                "axis": [
+                  {
+                    "input": "axisX",
+                    "output": "rightJoystickX",
+                    "sensitivity": 3
+                  },
+                  {
+                    "input": "axisY",
+                    "output": "rightJoystickY",
+                    "sensitivity": 3
+                  }
+                ],
+                "renderAsButton": true,
+                "action": "rightTrigger",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "fire"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "action": "leftThumb",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "sprint"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "action": "gamepadX",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "reload"
+                    }
+                  }
+                }
+              }
+            ],
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "leftBumper"
+            }
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Plateup!
![bx_plateup](https://github.com/redphx/better-xcloud/assets/149154024/83c7e478-ff19-4697-b1e6-ccd402c3fbac)

Roboquest (with gyro support)
![bx_roboquest](https://github.com/redphx/better-xcloud/assets/149154024/82cec675-10aa-4b26-9d52-3bce0f870822)

In addition, the gyroscope sensitivity of Halo Infinite was adjusted. Specifically, the sensitivity settings for the X-axis and Y-axis were separated, and the sensitivity of the Y-axis was reduced.