### PR TITLE
[Plateup!] Change to pull botton layout.

### DIFF
--- a/touch-layouts/layouts/plateup.json
+++ b/touch-layouts/layouts/plateup.json
@@ -18,24 +18,35 @@
                 }
               }
             }
-          ],
-          "outer": [
-            null,
-            null,
-            [
-              {
-                "type": "directionalPad",
-                "scale": 1.2
-              }
-            ]
           ]
         },
         "right": {
           "inner": [
             {
               "type": "button",
+              "action": "leftBumper",
+              "pullAction": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "character"
+                  }
+                },
+                "pulled": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "gamepadA"
+                  }
+                }
+              }
+            },
+            null,
+            {
+              "type": "button",
               "action": "gamepadA"
-            }
+            },
+            null
           ],
           "outer": [
             null,
@@ -51,10 +62,7 @@
                 }
               }
             },
-            {
-              "type": "button",
-              "action": "leftBumper"
-            },
+            null,
             null,
             null,
             {
@@ -69,22 +77,25 @@
                 }
               }
             },
-            null,
-            [
-              {
-                "type": "button",
-                "action": "gamepadY",
-                "styles": {
-                  "default": {
-                    "faceImage": {
-                      "type": "icon",
-                      "value": "accept"
-                    }
+            {
+              "type": "button",
+              "action": "leftBumper",
+              "pullAction": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                },
+                "pulled": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "gamepadX"
                   }
                 }
-              },
-              null
-            ]
+              }
+            }
           ]
         },
         "upper": {
@@ -92,6 +103,18 @@
             {
               "type": "button",
               "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "accept"
+                  }
+                }
+              }
             }
           ]
         }


### PR DESCRIPTION
**"Plateup!", "Roboquest" and Adjust gyroscope sensitivity in Halo Infinite.** (#289)

![1710346181037](https://github.com/redphx/better-xcloud/assets/149154024/3b0dc9cb-b4dd-4bd9-b170-0d05f2f5e1c2)

The upper `interact` and `character` buttons on the right side are set to `pullAction`, and each button is oriented by LB if simply tapped, and if the action is performed as is, the button is pulled so that `gamepadX` or `gamepadA` is to be pressed.

Also, I tried removing `expand: false`, but personally I felt it made the joystick range wider than necessary and made it harder to operate.
Plateup!" does not change the walking speed even if the stick input is slightly maxed out, so I think it is fine to disable `expand: false`.

We have tried to set the face icons for the pullaction buttons with `character` and `interact` respectively, but feel free to change them if you have a better idea.