### PR TITLE
Cyberpunk 2077: Minor changes

### DIFF
--- a/touch-layouts/layouts/cyberpunk-2077.json
+++ b/touch-layouts/layouts/cyberpunk-2077.json
@@ -50,7 +50,20 @@
             ],
             null,
             {
-              "type": "button",
+              "type": "touchpad",
+              "axis": [
+                {
+                  "input": "axisX",
+                  "output": "relativeMouseX",
+                  "sensitivity": 20
+                },
+                {
+                  "input": "axisY",
+                  "output": "relativeMouseY",
+                  "sensitivity": 20
+                }
+              ],
+              "renderAsButton": true,
               "action": "leftBumper",
               "styles": {
                 "default": {
@@ -263,21 +276,7 @@
                 }
               }
             ],
-            {
-              "type": "touchpad",
-              "axis": [
-                {
-                  "input": "axisX",
-                  "output": "relativeMouseX",
-                  "sensitivity": 20
-                },
-                {
-                  "input": "axisY",
-                  "output": "relativeMouseY",
-                  "sensitivity": 20
-                }
-              ]
-            },
+            null,
             {
               "type": "touchpad",
               "axis": [
@@ -335,7 +334,20 @@
                 ],
                 null,
                 {
-                  "type": "button",
+                  "type": "touchpad",
+                  "axis": [
+                    {
+                      "input": "axisX",
+                      "output": "relativeMouseX",
+                      "sensitivity": 20
+                    },
+                    {
+                      "input": "axisY",
+                      "output": "relativeMouseY",
+                      "sensitivity": 20
+                    }
+                  ],
+                  "renderAsButton": true,
                   "action": "leftBumper",
                   "styles": {
                     "default": {

--- a/touch-layouts/layouts/cyberpunk-2077.json
+++ b/touch-layouts/layouts/cyberpunk-2077.json
@@ -54,12 +54,12 @@
               "axis": [
                 {
                   "input": "axisX",
-                  "output": "relativeMouseX",
+                  "output": "rightJoystickX",
                   "sensitivity": 20
                 },
                 {
                   "input": "axisY",
-                  "output": "relativeMouseY",
+                  "output": "rightJoystickY",
                   "sensitivity": 20
                 }
               ],
@@ -79,24 +79,22 @@
         "right": {
           "inner": [
             {
-              "type": "touchpad",
-              "axis": [
-                {
-                  "input": "axisX",
-                  "output": "relativeMouseX",
-                  "sensitivity": 20
-                },
-                {
-                  "input": "axisY",
-                  "output": "relativeMouseY",
-                  "sensitivity": 20
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick",
+                "deadzone": {
+                  "threshold": 0.01,
+                  "radial": true
                 }
-              ],
+              },
               "styles": {
                 "default": {
-                  "faceImage": {
-                    "type": "icon",
-                    "value": "look"
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "look"
+                    }
                   }
                 }
               }
@@ -152,12 +150,12 @@
               "axis": [
                 {
                   "input": "axisX",
-                  "output": "relativeMouseX",
+                  "output": "rightJoystickX",
                   "sensitivity": 20
                 },
                 {
                   "input": "axisY",
-                  "output": "relativeMouseY",
+                  "output": "rightJoystickY",
                   "sensitivity": 20
                 }
               ],
@@ -177,12 +175,12 @@
               "axis": [
                 {
                   "input": "axisX",
-                  "output": "relativeMouseX",
+                  "output": "rightJoystickX",
                   "sensitivity": 20
                 },
                 {
                   "input": "axisY",
-                  "output": "relativeMouseY",
+                  "output": "rightJoystickY",
                   "sensitivity": 20
                 }
               ],
@@ -203,12 +201,12 @@
                 "axis": [
                   {
                     "input": "axisX",
-                    "output": "relativeMouseX",
+                    "output": "rightJoystickX",
                     "sensitivity": 20
                   },
                   {
                     "input": "axisY",
-                    "output": "relativeMouseY",
+                    "output": "rightJoystickY",
                     "sensitivity": 20
                   }
                 ],
@@ -228,12 +226,12 @@
                 "axis": [
                   {
                     "input": "axisX",
-                    "output": "relativeMouseX",
+                    "output": "rightJoystickX",
                     "sensitivity": 20
                   },
                   {
                     "input": "axisY",
-                    "output": "relativeMouseY",
+                    "output": "rightJoystickY",
                     "sensitivity": 20
                   }
                 ],
@@ -253,12 +251,12 @@
                 "axis": [
                   {
                     "input": "axisX",
-                    "output": "relativeMouseX",
+                    "output": "rightJoystickX",
                     "sensitivity": 20
                   },
                   {
                     "input": "axisY",
-                    "output": "relativeMouseY",
+                    "output": "rightJoystickY",
                     "sensitivity": 20
                   }
                 ],
@@ -282,12 +280,12 @@
               "axis": [
                 {
                   "input": "axisX",
-                  "output": "relativeMouseX",
+                  "output": "rightJoystickX",
                   "sensitivity": 20
                 },
                 {
                   "input": "axisY",
-                  "output": "relativeMouseY",
+                  "output": "rightJoystickY",
                   "sensitivity": 20
                 }
               ],
@@ -338,12 +336,12 @@
                   "axis": [
                     {
                       "input": "axisX",
-                      "output": "relativeMouseX",
+                      "output": "rightJoystickX",
                       "sensitivity": 20
                     },
                     {
                       "input": "axisY",
-                      "output": "relativeMouseY",
+                      "output": "rightJoystickY",
                       "sensitivity": 20
                     }
                   ],


### PR DESCRIPTION
- Remove a leftover touchpad I hadn't seen
- Add touchpad to leftbumper
- Remove relativeMouse and replace with rightJoystick due to an annoying issue where the displayed controls would constantly switch between mkb and controller