### PR TITLE
Custom controls for Playdead’s LIMBO and INSIDE.

### DIFF
--- a/touch-layouts/398011207.json
+++ b/touch-layouts/398011207.json
@@ -1,0 +1,7 @@
+{
+  "name": "LIMBO",
+  "default_layout": "custom",
+  "layouts": [
+    "limbo"
+  ]
+}

--- a/touch-layouts/885488152.json
+++ b/touch-layouts/885488152.json
@@ -1,0 +1,7 @@
+{
+  "name": "INSIDE",
+  "default_layout": "custom",
+  "layouts": [
+    "inside"
+  ]
+}

--- a/touch-layouts/layouts/inside.json
+++ b/touch-layouts/layouts/inside.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "custom",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "expand": false,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "jump"
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/touch-layouts/layouts/inside.json
+++ b/touch-layouts/layouts/inside.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "layouts": {
     "custom": {
-      "name": "custom",
+      "name": "Custom",
       "content": {
         "left": {
           "inner": [

--- a/touch-layouts/layouts/limbo.json
+++ b/touch-layouts/layouts/limbo.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "custom",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "expand": false,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "jump"
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/touch-layouts/layouts/limbo.json
+++ b/touch-layouts/layouts/limbo.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "layouts": {
     "custom": {
-      "name": "custom",
+      "name": "Custom",
       "content": {
         "left": {
           "inner": [


### PR DESCRIPTION
I’ve created custom touch controls for Playdead’s “LIMBO” and “INSIDE”. Both games use the same button layout. (Left stick, A & X buttons).

LIMBO:
![IMG_9843](https://github.com/redphx/better-xcloud/assets/162533196/62123f15-6192-444e-8d88-7e78dac5c663)

INSIDE:
![IMG_9844](https://github.com/redphx/better-xcloud/assets/162533196/a7486e30-ad89-4d53-b83e-cbd32c67a78b)


