### PR TITLE
Custom touch controls for “Resident Evil”.

### DIFF
--- a/touch-layouts/1278031123.json
+++ b/touch-layouts/1278031123.json
@@ -1,0 +1,7 @@
+{
+  "name": "Resident Evil",
+  "default_layout": "alternate",
+  "layouts": [
+    "resident-evil"
+  ]
+}

--- a/touch-layouts/1278031123.json
+++ b/touch-layouts/1278031123.json
@@ -1,6 +1,6 @@
 {
   "name": "Resident Evil",
-  "default_layout": "alternate",
+  "default_layout": "custom",
   "layouts": [
     "resident-evil"
   ]

--- a/touch-layouts/layouts/resident-evil.json
+++ b/touch-layouts/layouts/resident-evil.json
@@ -1,0 +1,229 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Alternate",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "expand": false,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            [
+              {
+                "type": "button",
+                "action": "rightJoystickDown",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "lookBehind"
+                    }
+                  }
+                }
+              }
+            ],
+            [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick",
+                  "deadzone": {
+                    "threshold": 0.05,
+                    "radial": true
+                  }
+                },
+                "action": "leftTrigger",
+                "styles": {
+                  "default": {
+                    "outline": {
+                      "indicator": {
+                        "type": "color",
+                        "value": "#ffffff"
+                      },
+                      "stroke": {
+                        "type": "solid",
+                        "color": "#ffffff"
+                      },
+                      "opacity": 0.1
+                    },
+                    "knob": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "aim"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            [
+              {
+                "type": "button",
+                "action": "leftBumper",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "leftBumper"
+                    }
+                  }
+                }
+              }
+            ],
+            null,
+            {
+              "type": "button",
+              "action": "rightTrigger",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "fire"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadB",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "reload"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": {
+                "type": "layer",
+                "target": "selectAbility"
+              },
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "add"
+                  }
+                }
+              },
+              "toggle": true
+            },
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "rightBumper",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "map"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "inventory"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "layers": {
+          "selectAbility": {
+            "left": {
+              "inner": [
+                {
+                  "type": "directionalPad",
+                  "scale": 2.2
+                }
+              ]
+            },
+            "right": {
+              "outer": [
+                null,
+                null,
+                [
+                  {
+                    "type": "button",
+                    "action": "leftBumper",
+                    "styles": {
+                      "default": {
+                        "faceImage": {
+                          "type": "icon",
+                          "value": "leftBumper"
+                        }
+                      }
+                    }
+                  }
+                ],
+                {
+                  "type": "button",
+                  "action": "gamepadX",
+                  "styles": {
+                    "default": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "sprint"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Custom touch controls for “Resident Evil” (Remote Play). To be used with the “Alternate” control option in game! Includes a layer to choose between analog/D Pad controls.

![image](https://github.com/user-attachments/assets/89dde5f9-e46f-4cdc-8aa4-85fa1024ed66)

![image](https://github.com/user-attachments/assets/d8947d5f-8ca6-455c-a96d-988d3afbec67)
