### PR TITLE
New custom touch controls for Resident Evil 4 Remake, Sonic Mania and Quake

### DIFF
--- a/touch-layouts/1714795112.json
+++ b/touch-layouts/1714795112.json
@@ -1,6 +1,6 @@
 {
   "name": "DOOM + DOOM II",
-  "default_layout": "custom",
+  "default_layout": "touchpad",
   "layouts": [
     "doom-doom-ii"
   ]

--- a/touch-layouts/1843641391.json
+++ b/touch-layouts/1843641391.json
@@ -1,0 +1,7 @@
+{
+  "name": "Quake",
+  "default_layout": "custom",
+  "layouts": [
+    "quake"
+  ]
+}

--- a/touch-layouts/1852916479.json
+++ b/touch-layouts/1852916479.json
@@ -1,0 +1,7 @@
+{
+  "name": "Resident Evil 4 Remake",
+  "default_layout": "type-a-1",
+  "layouts": [
+    "resident-evil-4-remake"
+  ]
+}

--- a/touch-layouts/2136041956.json
+++ b/touch-layouts/2136041956.json
@@ -1,7 +1,7 @@
 {
   "name": "DOOM 64",
   "product_id": "9MXND4PQLK3W",
-  "default_layout": "custom",
+  "default_layout": "touchpad",
   "layouts": [
     "doom-64"
   ]

--- a/touch-layouts/884612576.json
+++ b/touch-layouts/884612576.json
@@ -1,0 +1,7 @@
+{
+  "name": "Sonic Mania",
+  "default_layout": "custom",
+  "layouts": [
+    "sonic-mania"
+  ]
+}

--- a/touch-layouts/layouts/doom-64.json
+++ b/touch-layouts/layouts/doom-64.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "layouts": {
-    "custom": {
-      "name": "Custom",
+    "touchpad": {
+      "name": "Touchpad",
       "author": "Kode-Z",
       "content": {
         "left": {
@@ -154,6 +154,138 @@
             }
           }
         ]
+      }
+    },
+    "joystick": {
+      "name": "Joystick",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              },
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "walk"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "leftBumper"
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick"
+              }
+            }
+          ],
+          "outer": [
+            {
+              "type": "button",
+              "action": "rightBumper"
+            },
+            null,
+            {
+              "type": "button",
+              "action": "leftTrigger",
+              "toggle": true,
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "sprint"
+                  }
+                }
+              }
+            },
+            null,
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
+            [
+              {
+                "type": "touchpad",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick",
+                  "sensitivity": 2.5
+                },
+                "action": "rightTrigger",
+                "renderAsButton": true,
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "fire"
+                    }
+                  }
+                }
+              }
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "map"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            }
+          ]
+        }
       }
     }
   }

--- a/touch-layouts/layouts/doom-doom-ii.json
+++ b/touch-layouts/layouts/doom-doom-ii.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "layouts": {
-    "custom": {
-      "name": "custom",
+    "touchpad": {
+      "name": "Touchpad",
       "author": "Kode-Z",
       "content": {
         "left": {
@@ -152,6 +152,140 @@
             }
           }
         ]
+      }
+    },
+    "joystick": {
+      "name": "Joystick",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "expand": true,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              }
+            }
+          ],
+          "outer": [
+            {
+              "type": "button",
+              "action": "rightBumper"
+            },
+            null,
+            [
+              {
+                "type": "directionalPad",
+                "interaction": {
+                  "activationType": "exclusive"
+                },
+                "scale": 1.2
+              }
+            ],
+            null,
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "leftBumper"
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick"
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "leftTrigger",
+              "toggle": true,
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "walk"
+                  }
+                }
+              }
+            },
+            null,
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
+            [
+              {
+                "type": "touchpad",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick",
+                  "sensitivity": 2.5
+                },
+                "action": "rightTrigger",
+                "renderAsButton": true,
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "fire"
+                    }
+                  }
+                }
+              }
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "map"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            },
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        }
       }
     }
   }

--- a/touch-layouts/layouts/quake.json
+++ b/touch-layouts/layouts/quake.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Custom",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "action": "leftThumb",
+              "actionThreshold": 2,
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick",
+                "deadzone": {
+                  "threshold": 0.05,
+                  "radial": true
+                }
+              },
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "walk"
+                    }
+                  }
+                },
+                "activated": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "sprint"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            [
+              {
+                "type": "directionalPad",
+                "scale": 0.8
+              }
+            ],
+            [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick",
+                  "deadzone": {
+                    "threshold": 0,
+                    "radial": true
+                  }
+                },
+                "action": "rightBumper",
+                "styles": {
+                  "default": {
+                    "outline": {
+                      "indicator": {
+                        "type": "color",
+                        "value": "#ffffff"
+                      },
+                      "stroke": {
+                        "type": "solid",
+                        "color": "#ffffff"
+                      },
+                      "opacity": 0.5
+                    },
+                    "knob": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "weaponSelect"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick",
+                "deadzone": {
+                  "threshold": 0,
+                  "radial": true
+                }
+              },
+              "styles": {
+                "default": {
+                  "outline": {
+                    "indicator": {
+                      "type": "color",
+                      "value": "#ffffff"
+                    },
+                    "stroke": {
+                      "type": "solid",
+                      "color": "#ffffff"
+                    },
+                    "opacity": 0.5
+                  },
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "look"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "jump"
+                  }
+                }
+              }
+            },
+            [
+              {
+                "type": "touchpad",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick",
+                  "sensitivity": 5,
+                  "deadzone": {
+                    "threshold": 0,
+                    "radial": true
+                  }
+                },
+                "renderAsButton": true,
+                "action": [
+                  "rightTrigger"
+                ],
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "fire"
+                    }
+                  }
+                }
+              },
+              null
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view"
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            },
+            {
+              "type": "button",
+              "action": "gamepadY"
+            },
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/touch-layouts/layouts/resident-evil-4-remake.json
+++ b/touch-layouts/layouts/resident-evil-4-remake.json
@@ -149,7 +149,10 @@
           ],
           "outer": [
             [
-              null,
+              {
+                "type": "button",
+                "action": "rightBumper"
+              },
               {
                 "type": "button",
                 "action": "rightThumb"

--- a/touch-layouts/layouts/resident-evil-4-remake.json
+++ b/touch-layouts/layouts/resident-evil-4-remake.json
@@ -1,0 +1,243 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "type-a-1": {
+      "name": "Type A-1",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              },
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "walk"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            null,
+            null,
+            [
+              {
+                "type": "directionalPad",
+                "interaction": {
+                  "activationType": "exclusive"
+                },
+                "scale": 1
+              }
+            ],
+            [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick",
+                  "deadzone": {
+                    "threshold": 0.05,
+                    "radial": true
+                  }
+                },
+                "action": "leftBumper",
+                "styles": {
+                  "default": {
+                    "outline": {
+                      "indicator": {
+                        "type": "color",
+                        "value": "#ffffff"
+                      },
+                      "stroke": {
+                        "type": "solid",
+                        "color": "#ffffff"
+                      },
+                      "opacity": 0.5
+                    },
+                    "knob": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "leftBumper"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "leftJoystick",
+                  "deadzone": {
+                    "threshold": 0.05,
+                    "radial": true
+                  }
+                },
+                "action": "leftTrigger",
+                "styles": {
+                  "default": {
+                    "outline": {
+                      "indicator": {
+                        "type": "color",
+                        "value": "#ffffff"
+                      },
+                      "stroke": {
+                        "type": "solid",
+                        "color": "#ffffff"
+                      },
+                      "opacity": 0.5
+                    },
+                    "knob": {
+                      "faceImage": {
+                        "type": "icon",
+                        "value": "aim"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "touchpad",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick",
+                "sensitivity": 5,
+                "deadzone": {
+                  "threshold": 0,
+                  "radial": true
+                }
+              },
+              "renderAsButton": true,
+              "action": [
+                "rightTrigger"
+              ],
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "fire"
+                  }
+                }
+              }
+            }
+          ],
+          "outer": [
+            [
+              {
+                "type": "button",
+                "action": "rightBumper",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "run"
+                    }
+                  }
+                }
+              },
+              null,
+              {
+                "type": "button",
+                "action": "gamepadB",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "crouch"
+                    }
+                  }
+                }
+              }
+            ],
+            [
+              {
+                "type": "button",
+                "action": "gamepadX",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "reload"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "button",
+                "action": "rightThumb"
+              },
+              {
+                "type": "button",
+                "action": "gamepadA",
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "interact"
+                    }
+                  }
+                }
+              }
+            ],
+            [
+              {
+                "type": "joystick",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick"
+                }
+              }
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "view",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "map"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "inventory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/touch-layouts/layouts/resident-evil-4-remake.json
+++ b/touch-layouts/layouts/resident-evil-4-remake.json
@@ -13,12 +13,23 @@
                 "input": "axisXY",
                 "output": "leftJoystick"
               },
+              "action": "leftThumb",
+              "relative": false,
+              "actionThreshold": 2,
               "styles": {
                 "default": {
                   "knob": {
                     "faceImage": {
                       "type": "icon",
                       "value": "walk"
+                    }
+                  }
+                },
+                "activated": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "sprint"
                     }
                   }
                 }
@@ -138,19 +149,11 @@
           ],
           "outer": [
             [
+              null,
               {
                 "type": "button",
-                "action": "rightBumper",
-                "styles": {
-                  "default": {
-                    "faceImage": {
-                      "type": "icon",
-                      "value": "run"
-                    }
-                  }
-                }
+                "action": "rightThumb"
               },
-              null,
               {
                 "type": "button",
                 "action": "gamepadB",
@@ -164,36 +167,30 @@
                 }
               }
             ],
-            [
-              {
-                "type": "button",
-                "action": "gamepadX",
-                "styles": {
-                  "default": {
-                    "faceImage": {
-                      "type": "icon",
-                      "value": "reload"
-                    }
-                  }
-                }
-              },
-              {
-                "type": "button",
-                "action": "rightThumb"
-              },
-              {
-                "type": "button",
-                "action": "gamepadA",
-                "styles": {
-                  "default": {
-                    "faceImage": {
-                      "type": "icon",
-                      "value": "interact"
-                    }
+            {
+              "type": "button",
+              "action": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "reload"
                   }
                 }
               }
-            ],
+            },
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
             [
               {
                 "type": "joystick",

--- a/touch-layouts/layouts/sonic-mania.json
+++ b/touch-layouts/layouts/sonic-mania.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Custom",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "directionalPad",
+              "scale": 2
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "jump"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "upper": {
+          "right": [
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "gamepadB"
+            },
+            {
+              "type": "button",
+              "action": "gamepadY"
+            },
+            {
+              "type": "button",
+              "action": "gamepadX"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added new touch controls for Resident Evil 4 Remake, Sonic Mania and Quake.

Resident Evil 4 Remake (Remote Play):
<img width="2796" height="1290" alt="IMG_4535" src="https://github.com/user-attachments/assets/4672b302-2dac-4a17-a847-98fbbc76e9fa" />

Sonic Mania (Remote Play):
<img width="2796" height="1290" alt="IMG_4598" src="https://github.com/user-attachments/assets/926912d7-d513-4b41-ad87-884009fcb5ff" />

Quake (Gamepass/Remote Play):
<img width="2796" height="1290" alt="IMG_4601" src="https://github.com/user-attachments/assets/0f6fbc13-2087-405d-8dbb-1b286c9ed3e3" />

I also added additional additional layouts to DOOM & DOOM II / DOOM 64.