### PR TITLE
Custom touch controls for Shenmue 1 & 2

### DIFF
--- a/touch-layouts/1022228933.json
+++ b/touch-layouts/1022228933.json
@@ -1,0 +1,7 @@
+{
+  "name": "Shenmue II",
+  "default_layout": "custom",
+  "layouts": [
+    "shenmue-1-and-2"
+  ]
+}

--- a/touch-layouts/114172147.json
+++ b/touch-layouts/114172147.json
@@ -1,0 +1,7 @@
+{
+  "name": "Shenmue",
+  "default_layout": "custom",
+  "layouts": [
+    "shenmue-1-and-2"
+  ]
+}

--- a/touch-layouts/layouts/resident-evil.json
+++ b/touch-layouts/layouts/resident-evil.json
@@ -49,21 +49,18 @@
                 "action": "leftTrigger",
                 "styles": {
                   "default": {
-                    "outline": {
-                      "indicator": {
-                        "type": "color",
-                        "value": "#ffffff"
-                      },
-                      "stroke": {
-                        "type": "solid",
-                        "color": "#ffffff"
-                      },
-                      "opacity": 0.1
-                    },
                     "knob": {
                       "faceImage": {
                         "type": "icon",
                         "value": "aim"
+                      },
+                      "background": {
+                        "type": "color",
+                        "value": "#ffffff",
+                        "opacity": 0.1
+                      },
+                      "stroke": {
+                        "opacity": 0.1
                       }
                     }
                   }

--- a/touch-layouts/layouts/shenmue-1-and-2.json
+++ b/touch-layouts/layouts/shenmue-1-and-2.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": 1,
+  "layouts": {
+    "custom": {
+      "name": "Custom",
+      "author": "Kode-Z",
+      "content": {
+        "left": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "leftJoystick"
+              },
+              "styles": {
+                "default": {
+                  "knob": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "walk"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "inner": [
+            {
+              "type": "joystick",
+              "axis": {
+                "input": "axisXY",
+                "output": "rightJoystick"
+              }
+            }
+          ],
+          "outer": [
+            [
+              null,
+              {
+                "type": "button",
+                "action": {
+                  "type": "layer",
+                  "target": "dPad"
+                },
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "dPad",
+                      "opacity": 0.5
+                    },
+                    "background": {
+                      "type": "color",
+                      "value": "#1992cf",
+                      "opacity": 0.2
+                    }
+                  }
+                },
+                "toggle": true
+              },
+              null
+            ],
+            {
+              "type": "button",
+              "action": "rightTrigger",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "sprint"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadB",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "close"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadA",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "interact"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadX",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "notebook"
+                  }
+                }
+              }
+            },
+            {
+              "type": "button",
+              "action": "gamepadY",
+              "styles": {
+                "default": {
+                  "faceImage": {
+                    "type": "icon",
+                    "value": "inventory"
+                  }
+                }
+              }
+            },
+            [
+              {
+                "type": "touchpad",
+                "axis": {
+                  "input": "axisXY",
+                  "output": "rightJoystick",
+                  "sensitivity": 5,
+                  "deadzone": {
+                    "threshold": 0,
+                    "radial": true
+                  }
+                },
+                "renderAsButton": true,
+                "action": [
+                  "leftTrigger"
+                ],
+                "styles": {
+                  "default": {
+                    "faceImage": {
+                      "type": "icon",
+                      "value": "look"
+                    }
+                  }
+                }
+              },
+              null
+            ]
+          ]
+        },
+        "upper": {
+          "right": [
+            null,
+            null,
+            {
+              "type": "button",
+              "action": "menu"
+            },
+            {
+              "type": "button",
+              "action": "rightTrigger"
+            },
+            {
+              "type": "button",
+              "action": "leftTrigger"
+            }
+          ]
+        },
+        "layers": {
+          "dPad": {
+            "left": {
+              "inner": [
+                {
+                  "type": "directionalPad",
+                  "scale": 2.2
+                }
+              ]
+            },
+            "right": {
+              "inner": [
+                {
+                  "type": "joystick",
+                  "axis": {
+                    "input": "axisXY",
+                    "output": "rightJoystick"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Custom touch controls for Shenmue 1 & 2.

_Includes a toggle to switch between D Pad and Joystick depending on your preference!_

Shenmue 1:
![IMG_4974](https://github.com/user-attachments/assets/fcfbbc78-8001-4a8c-a891-62631325e55b)
![IMG_4973](https://github.com/user-attachments/assets/dfca9b17-72bb-422f-9900-67fdecbf97b4)

Shenmue 2:
![image](https://github.com/user-attachments/assets/8c7a4997-939e-422e-82fe-ae2e067a3d5c)
![image](https://github.com/user-attachments/assets/f5276572-7b7f-4ee0-8955-66b7e8adc9ec)


Added opacity adjustments to Resident Evil 1 Remake.