### PR TITLE
perf(startup): defer stream.video.codecProfile computation (WebRTC stack init)

### DIFF
--- a/src/utils/monkey-patches.ts
+++ b/src/utils/monkey-patches.ts
@@ -7,7 +7,7 @@ import { GlobalPref, StreamPref } from "@/enums/pref-keys";
 import { CodecProfile } from "@/enums/pref-values";
 import type { SettingDefinition } from "@/types/setting-definition";
 import { BxEventBus } from "./bx-event-bus";
-import { getGlobalPref, getGlobalPrefDefinition, getStreamPref } from "@/utils/pref-utils";
+import { getGlobalPref, getGlobalPrefDefinition, getStreamPref, STORAGE } from "@/utils/pref-utils";
 import type { StreamPlayerOptions } from "@/types/stream";
 
 export function patchVideoApi() {
@@ -68,7 +68,11 @@ export function patchVideoApi() {
 
 
 export function patchRtcCodecs() {
-    const codecProfile = getGlobalPref(GlobalPref.STREAM_CODEC_PROFILE);
+    // Read the raw stored value: getGlobalPref() would trigger validateValue →
+    // definition.options access → RTCRtpReceiver.getCapabilities() (WebRTC
+    // stack init, ~600 ms one-shot). The stored value is absent unless the
+    // user configured the setting.
+    const codecProfile = (STORAGE.Global.settings as Record<string, CodecProfile | undefined>)[GlobalPref.STREAM_CODEC_PROFILE] ?? CodecProfile.DEFAULT;
     if (codecProfile === 'default') {
         return;
     }
@@ -90,7 +94,9 @@ export function patchRtcPeerConnection() {
 
     const maxVideoBitrateDef = getGlobalPrefDefinition(GlobalPref.STREAM_MAX_VIDEO_BITRATE) as Extract<SettingDefinition, { min: number }>;
     const maxVideoBitrate = getGlobalPref(GlobalPref.STREAM_MAX_VIDEO_BITRATE);
-    const codec = getGlobalPref(GlobalPref.STREAM_CODEC_PROFILE);
+    // Same as patchRtcCodecs: avoid getGlobalPref() on STREAM_CODEC_PROFILE
+    // (it would trigger getCapabilities() via the lazy options getter).
+    const codec = (STORAGE.Global.settings as Record<string, CodecProfile | undefined>)[GlobalPref.STREAM_CODEC_PROFILE] ?? CodecProfile.DEFAULT;
 
     if (codec !== CodecProfile.DEFAULT || maxVideoBitrate < maxVideoBitrateDef.max) {
         const nativeSetLocalDescription = RTCPeerConnection.prototype.setLocalDescription;

--- a/src/utils/settings-storages/global-settings-storage.ts
+++ b/src/utils/settings-storages/global-settings-storage.ts
@@ -13,13 +13,22 @@ import { GhPagesUtils } from "../gh-pages";
 import { BxEventBus } from "../bx-event-bus";
 
 
+// Result is constant per browser session (the WebRTC stack doesn't change at
+// runtime), so it is memoized: the first call pays the one-shot
+// RTCRtpReceiver.getCapabilities() cost, later accesses are free.
+let codecProfilesCache: PartialRecord<CodecProfile, string> | null = null;
+
 function getSupportedCodecProfiles() {
+    if (codecProfilesCache) {
+        return codecProfilesCache;
+    }
+
     const options: PartialRecord<CodecProfile, string> = {
         default: t('default'),
     };
 
     if (!('getCapabilities' in RTCRtpReceiver)) {
-        return options;
+        return (codecProfilesCache = options);
     }
 
     let hasLowCodec = false;
@@ -66,7 +75,7 @@ function getSupportedCodecProfiles() {
         }
     }
 
-    return options;
+    return (codecProfilesCache = options);
 }
 
 export class GlobalSettingsStorage extends BaseSettingsStorage<GlobalPref> {
@@ -160,20 +169,35 @@ export class GlobalSettingsStorage extends BaseSettingsStorage<GlobalPref> {
         [GlobalPref.STREAM_CODEC_PROFILE]: {
             label: t('visual-quality'),
             default: CodecProfile.DEFAULT,
-            options: getSupportedCodecProfiles(),
+            // Lazy: RTCRtpReceiver.getCapabilities() initializes the WebRTC
+            // stack (~600 ms one-shot on cold starts), so it must not run at
+            // startup. The getter only fires when the setting is actually
+            // rendered/validated, and getSupportedCodecProfiles() memoizes
+            // the result for subsequent accesses.
+            get options() { return getSupportedCodecProfiles(); },
             ready: (setting: SettingDefinition) => {
-                const options = (setting as any).options;
-                const keys = Object.keys(options);
-
-                if (keys.length <= 1) { // Unsupported
-                    setting.unsupported = true;
-                    setting.unsupportedNote = '⚠️ ' + t('browser-unsupported-feature');
-                }
-
-                setting.suggest = {
-                    lowest: keys.length === 1 ? keys[0] : keys[1],
-                    highest: keys[keys.length - 1],
-                };
+                // No computation here (ready runs eagerly at construction):
+                // expose lazy getters instead, computed on first access.
+                Object.defineProperties(setting, {
+                    unsupported: {
+                        get() { return Object.keys(this.options).length <= 1; },
+                        configurable: true,
+                    },
+                    unsupportedNote: {
+                        get() { return this.unsupported ? '⚠️ ' + t('browser-unsupported-feature') : undefined; },
+                        configurable: true,
+                    },
+                    suggest: {
+                        get() {
+                            const keys = Object.keys(this.options);
+                            return {
+                                lowest: keys.length === 1 ? keys[0] : keys[1],
+                                highest: keys[keys.length - 1],
+                            };
+                        },
+                        configurable: true,
+                    },
+                });
             },
         },
         [GlobalPref.SERVER_PREFER_IPV6]: {


### PR DESCRIPTION
## What

`stream.video.codecProfile` options are computed **eagerly at startup**:

- `GlobalSettingsStorage.DEFINITIONS` calls `getSupportedCodecProfiles()` at construction
- `patchRtcCodecs()` / `patchRtcPeerConnection()` call `getGlobalPref(STREAM_CODEC_PROFILE)`, which triggers `validateValue()` → accesses `definition.options` → `RTCRtpReceiver.getCapabilities('video')`

`RTCRtpReceiver.getCapabilities()` initializes the whole WebRTC stack in the browser. Measured on a cold Edge start: **~600 ms one-shot** for this single call (and it was called before the settings dialog was ever opened).

This PR defers it:

1. **Memoize** `getSupportedCodecProfiles()` — the result is constant per browser session, the one-shot cost is paid at most once (first actual use).
2. **Lazy `options` getter** on the setting definition.
3. **`ready()`** (which runs eagerly at construction) now only defines lazy getters for `unsupported` / `unsupportedNote` / `suggest` — no computation at startup.
4. **`patchRtcCodecs` / `patchRtcPeerConnection`** read the raw stored value (`STORAGE.Global.settings[...]`) instead of `getGlobalPref()`, which would trigger the options getter.

## Why it's safe

- The codec profile dropdown, the unsupported state and the suggest values are **identical**, only computed on first actual use (settings dialog opened, or codec profile configured).
- Users who configured `stream.video.codecProfile` keep the exact same behavior (validateValue on the stored key is memoized).

## Measurement

From the perf fork bench (CDP startup profile, cold Edge):

| | `getSupportedCodecProfiles` self time |
|---|---|
| before | 19.7 ms **dominant (76 %)** in the startup profile; ~600 ms one-shot RTC init on cold start |
| after | absent from the startup profile (nothing JS-dominant left) |

Behavior-neutral, pure startup saving.
