### PR TITLE
fix(webgl2): correct viewport height, add opt-in WebGL2NoColorConversion flag

### DIFF
--- a/src/modules/player/webgl2/webgl2-player.ts
+++ b/src/modules/player/webgl2/webgl2-player.ts
@@ -2,6 +2,7 @@ import { compressCodeFile } from "@macros/build" with { type: "macro" };
 
 import { StreamPref } from "@/enums/pref-keys";
 import { getStreamPref } from "@/utils/pref-utils";
+import { BX_FLAGS } from "@/utils/bx-flags";
 import { BaseCanvasPlayer } from "../base-canvas-player";
 import { StreamPlayerType, StreamVideoProcessingMode } from "@/enums/pref-values";
 
@@ -50,7 +51,12 @@ export class WebGL2Player extends BaseCanvasPlayer {
         } as WebGLContextAttributes) as WebGL2RenderingContext;
         this.gl = gl;
 
-        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferWidth);
+        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+        // Skip the browser color management on video uploads. Slight color shift possible.
+        if (BX_FLAGS.WebGL2NoColorConversion) {
+            gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        }
 
         // Vertex shader: Identity map
         const vShader = gl.createShader(gl.VERTEX_SHADER)!;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -180,6 +180,7 @@ type BxFlags = {
     SafariWorkaround: boolean;
 
     EnableWebGPURenderer: boolean;
+    WebGL2NoColorConversion: boolean;
 
     ForceNativeMkbTitles: string[];
     FeatureGates: { [key: string]: boolean } | null,

--- a/src/utils/bx-flags.ts
+++ b/src/utils/bx-flags.ts
@@ -9,6 +9,7 @@ const DEFAULT_FLAGS: BxFlags = {
     SafariWorkaround: true,
 
     EnableWebGPURenderer: false,
+    WebGL2NoColorConversion: false,
 
     ForceNativeMkbTitles: [],
     FeatureGates: null,


### PR DESCRIPTION
## Quoi

Deux corrections indépendantes du renderer WebGL2, dans un seul fichier + le flag associé :

1. **Viewport corrigé** : `gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferWidth)` utilisait la **largeur pour la hauteur**. Avec un canvas non carré, le rendu était étiré/recadré. Correct : `gl.drawingBufferHeight`.
2. **Flag opt-in `WebGL2NoColorConversion`** : `gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE)` saute la gestion des couleurs du navigateur sur les uploads vidéo — un léger décalage de couleurs est possible, le flag est **désactivé par défaut** (`DEFAULT_FLAGS` + type `BxFlags`).

## Pourquoi c'est sûr

- Comportement par défaut **inchangé** (le flag est `false`).
- Le viewport est une vraie correction : les deux dimensions du drawing buffer existent, la hauteur était simplement mal lue.
- Aucun chemin appelé en plus — `pixelStorei` n'est exécuté que si le flag est activé par le build (`window.BX_FLAGS`).

## Détails

- 3 fichiers : `webgl2-player.ts` (+7/−1), `bx-flags.ts` (+1), `types/index.d.ts` (+1)
- Build : `bun build.ts --version 6.7.12 --variant full` → exit 0 (gate eslint + TS)
- Le bundle régénéré ne contient que ces changements (aucune fuite d'autres patches)
