### PR TITLE
perf(stream-stats): throttle the stats tick when the tab is hidden

### DIFF
--- a/src/modules/stream/stream-stats.ts
+++ b/src/modules/stream/stream-stats.ts
@@ -16,7 +16,19 @@ export class StreamStats {
 
     private isRunning = false;
     private intervalId?: number | null;
+    private isUpdating = false;
     private readonly REFRESH_INTERVAL = 1 * 1000;
+
+    private getInterval() {
+        return document.hidden ? StreamStatsCollector.INTERVAL_BACKGROUND : this.REFRESH_INTERVAL;
+    }
+
+    private onVisibilityChanged = () => {
+        if (!this.isRunning) return;
+        this.intervalId && clearTimeout(this.intervalId);
+        this.intervalId = null;
+        this.update();
+    };
 
     private stats = {
         [StreamStat.CLOCK]: {
@@ -82,6 +94,8 @@ export class StreamStats {
         this.boundOnStreamHudStateChanged = this.onStreamHudStateChanged.bind(this);
         BxEventBus.Stream.on('ui.streamHud.rendered', this.boundOnStreamHudStateChanged);
 
+        document.addEventListener('visibilitychange', this.onVisibilityChanged);
+
         this.render();
     }
 
@@ -91,13 +105,11 @@ export class StreamStats {
         }
 
         this.isRunning = true;
-        this.intervalId && clearInterval(this.intervalId);
+        this.intervalId && clearTimeout(this.intervalId);
         await this.update(true);
 
         this.$container.classList.remove('bx-gone');
         this.$container.dataset.display = glancing ? 'glancing' : 'fixed';
-
-        this.intervalId = window.setInterval(this.update, this.REFRESH_INTERVAL);
     }
 
     async stop(glancing=false) {
@@ -106,7 +118,7 @@ export class StreamStats {
         }
 
         this.isRunning = false;
-        this.intervalId && clearInterval(this.intervalId);
+        this.intervalId && clearTimeout(this.intervalId);
         this.intervalId = null;
 
         this.$container.removeAttribute('data-display');
@@ -142,34 +154,46 @@ export class StreamStats {
     }
 
     private update = async (forceUpdate=false) => {
+        if (this.isUpdating) return;
+
         if ((!forceUpdate && this.isHidden()) || !STATES.currentStream.peerConnection) {
             this.destroy();
             return;
         }
 
-        const PREF_STATS_CONDITIONAL_FORMATTING = getStreamPref(StreamPref.STATS_CONDITIONAL_FORMATTING);
-        let grade: StreamStatGrade = '';
+        this.isUpdating = true;
+        try {
+            const PREF_STATS_CONDITIONAL_FORMATTING = getStreamPref(StreamPref.STATS_CONDITIONAL_FORMATTING);
+            let grade: StreamStatGrade = '';
 
-        // Collect stats
-        const statsCollector = StreamStatsCollector.getInstance();
-        await statsCollector.collect();
+            // Collect stats
+            const statsCollector = StreamStatsCollector.getInstance();
+            await statsCollector.collect();
 
-        let statKey: keyof typeof this.stats;
-        for (statKey in this.stats) {
-            grade = '';
+            let statKey: keyof typeof this.stats;
+            for (statKey in this.stats) {
+                grade = '';
 
-            const stat = this.stats[statKey];
-            const value = statsCollector.getStat(statKey);
-            const $element = stat.$element;
-            $element.textContent = value.toString();
+                const stat = this.stats[statKey];
+                const value = statsCollector.getStat(statKey);
+                const $element = stat.$element;
+                $element.textContent = value.toString();
 
-            // Get stat's grade
-            if (PREF_STATS_CONDITIONAL_FORMATTING && 'grades' in value) {
-                grade = statsCollector.calculateGrade(value.current, value.grades);
+                // Get stat's grade
+                if (PREF_STATS_CONDITIONAL_FORMATTING && 'grades' in value) {
+                    grade = statsCollector.calculateGrade(value.current, value.grades);
+                }
+
+                if ($element.dataset.grade !== grade) {
+                    $element.dataset.grade = grade;
+                }
             }
+        } finally {
+            this.isUpdating = false;
 
-            if ($element.dataset.grade !== grade) {
-                $element.dataset.grade = grade;
+            if (this.isRunning) {
+                this.intervalId && clearTimeout(this.intervalId);
+                this.intervalId = window.setTimeout(this.update, this.getInterval());
             }
         }
     }


### PR DESCRIPTION
## Quoi

La barre de stats (StreamStats) appelle `getStats()` toutes les secondes même quand l'onglet est **caché** — inutile (rien de visible à rafraîchir) mais le coût CPU/batterie reste là. Trois changements dans un seul fichier (`stream-stats.ts`) :

1. **Throttle `document.hidden`** : le tick passe de `REFRESH_INTERVAL` (1 s, onglet visible) à `StreamStatsCollector.INTERVAL_BACKGROUND` (60 s, onglet caché) via `getInterval()`.
2. **`setInterval` → `setTimeout` auto-réarmé** : l'intervalle est **réévalué à chaque tick** (le réarmement se fait en fin d'`update`, pas une fois au `start`) → au retour au premier plan, la cadence 1 s reprend immédiatement.
3. **Refresh immédiat au retour** : un listener `visibilitychange` déclenche une mise à jour dès que l'onglet redevient visible (pas d'attente du prochain tick).

Au passage, `update()` est protégé contre la **réentrance** (`isUpdating` flag + try/finally) : `collect()` est async, un `getStats()` lent ne peut plus chevaucher le tick suivant.

## Pourquoi c'est sûr

- **Aucun changement quand l'onglet est visible** : cadence 1 s identique, mêmes valeurs, même rendu.
- Le flag `isUpdating` ne change que le timing de la boucle — `collect()`/`getStat()`/rendu intacts.
- La constante `INTERVAL_BACKGROUND = 60 * 1000` existait déjà dans `StreamStatsCollector` (inutilisée) — le patch la branche, zéro nouvelle valeur magique.
- Le listener `visibilitychange` est ajouté dans le constructeur, aucun retrait nécessaire (la classe est un singleton de session).

## Détails

- 1 fichier : `src/modules/stream/stream-stats.ts` (+45/−21)
- Build : `bun build.ts --version 6.7.12 --variant full` → exit 0 (gate eslint + TS)
- Mesure (fork) : la barre de stats 1 s en arrière-plan coûtait un `getStats()` complet par seconde ; passé à 1/60 s quand l'onglet est caché — le gain dépend du temps de `collect()` (report RTC de ~50 entrées ≈ µs), mais supprime **59/60 des appels `getStats()`** sur un stream en arrière-plan (lecture prolongée + autre onglet actif, scénario courant).
