### PR TITLE
fix(controller): stop deleting the Share mapping from stored settings

### DIFF
--- a/src/modules/patcher/patches/src/controller-customization.ts
+++ b/src/modules/patcher/patches/src/controller-customization.ts
@@ -75,9 +75,13 @@ if (currentGamepad.id in window.BX_STREAM_SETTINGS.controllers) {
                 pressedButtons[targetButton] = 1;
             }
 
-            // Don't send capturing request
+            // Don't send capturing request.
+            // Note: do NOT delete the key from the mapping — `mapping` is a
+            // live reference to the stored settings
+            // (`BX_STREAM_SETTINGS.controllers[...].customization.mapping`),
+            // so deleting it would permanently wipe the user's Share mapping
+            // after the first press.
             shareButtonHandled = true;
-            delete mapping['Share'];
         }
 
         // Handle other buttons


### PR DESCRIPTION
## Bug

When the Share button is pressed and the controller has a customization mapping, the patch handled the Share press and then executed:

```ts
delete mapping['Share'];
```

`mapping` is a **live reference** to the stored settings object (`window.BX_STREAM_SETTINGS.controllers[...].customization.mapping`) — not a copy. So the first time the user presses Share, their configured Share mapping is **permanently deleted from their saved configuration**:

- the remap silently stops working from the next session on,
- the user has to reconfigure the Share button from scratch,
- and because the key is gone from storage, re-entering the settings shows no Share mapping at all.

## Fix

Remove the `delete`. The surrounding logic is unchanged and idempotent:

- the mapped target button is still sent via `pressedButtons[targetButton] = 1`,
- `shareButtonHandled = true` still suppresses the default screenshot capture,
- the mapping is re-read on every press, so nothing is lost from the stored config.

## Verification

- Build: exit 0 (eslint + TS gate).
- Bundle: `delete mapping.Share` gone, `pressedButtons` handling and the screenshot guard intact.
- No behavioral change other than the destructive delete being removed.