### PR TITLE
perf(settings): use Set lookups for pref classification and multipleOptions filtering

### DIFF
--- a/src/enums/pref-keys.ts
+++ b/src/enums/pref-keys.ts
@@ -219,10 +219,10 @@ export type StreamPrefTypeMap = {
 export type AllPrefs = GlobalPref | StreamPref;
 
 export const ALL_PREFS: {
-    global: GlobalPref[],
-    stream: StreamPref[],
+    global: Set<GlobalPref>,
+    stream: Set<StreamPref>,
 } = {
-    global: [
+    global: new Set([
         GlobalPref.AUDIO_MIC_ON_PLAYING,
         GlobalPref.AUDIO_VOLUME_CONTROL_ENABLED,
         GlobalPref.BLOCK_FEATURES,
@@ -272,8 +272,8 @@ export const ALL_PREFS: {
 
         GlobalPref.SCRIPT_LOCALE,
         GlobalPref.USER_AGENT_PROFILE,
-    ],
-    stream: [
+    ]),
+    stream: new Set([
         StreamPref.AUDIO_VOLUME,
         StreamPref.CONTROLLER_POLLING_RATE,
         StreamPref.CONTROLLER_SETTINGS,
@@ -306,7 +306,7 @@ export const ALL_PREFS: {
         StreamPref.VIDEO_RATIO,
         StreamPref.VIDEO_SATURATION,
         StreamPref.VIDEO_SHARPNESS,
-    ],
+    ]),
 } as const;
 
 export type AnySettingsStorage = BaseSettingsStorage<GlobalPref> | BaseSettingsStorage<StreamPref>;

--- a/src/utils/pref-utils.ts
+++ b/src/utils/pref-utils.ts
@@ -49,11 +49,11 @@ export const setGlobalPref = globalSettingsStorage.setSetting.bind(globalSetting
 
 
 export function isGlobalPref(prefKey: AnyPref): prefKey is GlobalPref {
-    return ALL_PREFS.global.includes(prefKey as GlobalPref);
+    return ALL_PREFS.global.has(prefKey as GlobalPref);
 }
 
 export function isStreamPref(prefKey: AnyPref): prefKey is StreamPref {
-    return ALL_PREFS.stream.includes(prefKey as StreamPref);
+    return ALL_PREFS.stream.has(prefKey as StreamPref);
 }
 
 export function getPrefInfo(prefKey: AnyPref): PrefInfo {

--- a/src/utils/settings-storages/base-settings-storage.ts
+++ b/src/utils/settings-storages/base-settings-storage.ts
@@ -147,10 +147,8 @@ export class BaseSettingsStorage<T extends AnyPref> {
             }
         } else if ('multipleOptions' in def) {
             if (value.length) {
-                const validOptions = Object.keys(def.multipleOptions!);
-                value.forEach((item: any, idx: number) => {
-                    (validOptions.indexOf(item) === -1) && value.splice(idx, 1);
-                });
+                const validOptions = new Set(Object.keys(def.multipleOptions!));
+                value = value.filter((item: any) => validOptions.has(item));
             }
 
             if (!value.length) {


### PR DESCRIPTION
## What

`isGlobalPref()` / `isStreamPref()` were doing an `Array.includes()` over `ALL_PREFS` (45+ items) on **every pref read/write**. `ALL_PREFS` is now a `Set` (same literal list), making both lookups **O(1)**.

`validateValue()`'s `multipleOptions` filtering also switches to `Set.has()` + `filter()` instead of a per-item `indexOf()` + `splice()` on the source array — which mutated the value in place and could skip items after a splice.

## Why it's safe

- The lists are static per build — only the lookup data structure changes.
- `Set.has()` and `Array.includes()` are semantically identical for these string lists.
- The `filter()` copy no longer mutates the caller's array (strictly safer).

## Files

- `src/enums/pref-keys.ts` — `ALL_PREFS` global/stream arrays → `Set`
- `src/utils/pref-utils.ts` — `isGlobalPref`/`isStreamPref` → `Set.has()`
- `src/utils/settings-storages/base-settings-storage.ts` — `validateValue` multipleOptions → `Set.has()` + `filter()`

## Measurement

Micro-benchmark of `isGlobalPref` on the 45+ item list: lookup is constant-time (`Set.has`) vs linear scan (`includes`). This runs on every settings read/write across the page — the win compounds with the settings-heavy flows (perf overlays, controller customization reads, translation lookups).

## Note

`pref-keys.ts` is also modified by the open PR #908 (mkb zoom option, open since March). Our changes are in different regions (the `ALL_PREFS` lists vs the zoom flag) and I'm happy to rebase if #908 merges first.