### PR TITLE
perf(update): only fetch the latest release when the 2h throttle elapses

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,15 +16,6 @@ export function checkForUpdate() {
         return;
     }
 
-    // Always check for new version
-    fetch('https://api.github.com/repos/redphx/better-xcloud/releases/latest')
-        .then(response => response.json())
-        .then(json => {
-            // Store the latest version
-            setGlobalPref(GlobalPref.VERSION_LATEST, json.tag_name.substring(1), 'direct');
-            setGlobalPref(GlobalPref.VERSION_CURRENT, SCRIPT_VERSION, 'direct');
-        });
-
     const CHECK_INTERVAL_SECONDS = 2 * 3600; // check every 2 hours
 
     const currentVersion = getGlobalPref(GlobalPref.VERSION_CURRENT);
@@ -40,6 +31,15 @@ export function checkForUpdate() {
 
     // Update translations
     Translations.updateTranslations(currentVersion === SCRIPT_VERSION);
+
+    // Always check for new version
+    fetch('https://api.github.com/repos/redphx/better-xcloud/releases/latest')
+        .then(response => response.json())
+        .then(json => {
+            // Store the latest version
+            setGlobalPref(GlobalPref.VERSION_LATEST, json.tag_name.substring(1), 'direct');
+            setGlobalPref(GlobalPref.VERSION_CURRENT, SCRIPT_VERSION, 'direct');
+        });
 }
 
 


### PR DESCRIPTION
## What

`checkForUpdate()` fires the GitHub releases API fetch **on every call**, even when the 2h `CHECK_INTERVAL_SECONDS` has not elapsed — the existing guard only skipped the translations refresh, not the API call.

The fetch now runs **after** the throttle check: the GitHub API is hit at most once every 2 hours instead of on every page load / call site.

## Why it's safe

- The first run still fetches (`lastCheck` defaults to 0), so update notifications are not delayed.
- When the throttle has elapsed, the fetch runs exactly as before.
- The version comparison, notification and translations refresh logic are untouched.

## Measurement

The update check runs on every page load (and at several call sites). Each call hit the GitHub releases API — network + JSON parse for nothing within the 2h window. This removes all of those redundant fetches: 1 API call per 2h max instead of 1 per page load.

## Files

- `src/utils/utils.ts` — fetch moved after the throttle guard