### PR TITLE
perf(ui): delegate BxSelect option re-rendering to a single global observer

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -547,7 +547,6 @@ export class Translations {
             }
             return true;
         } catch (e) {
-            debugger;
         }
 
         return false;

--- a/src/web-components/bx-select.ts
+++ b/src/web-components/bx-select.ts
@@ -19,6 +19,42 @@ export class BxSelectElement extends HTMLSelectElement {
     private $label!: HTMLSpanElement;
     private $checkBox!: HTMLInputElement;
 
+    private static observer: MutationObserver | null = null;
+
+    private static ensureObserver() {
+        if (BxSelectElement.observer) return;
+        BxSelectElement.observer = new MutationObserver(BxSelectElement.onMutation);
+        BxSelectElement.observer.observe(document.documentElement, {
+            subtree: true,
+            childList: true,
+            attributes: true,
+        });
+    }
+
+    private static onMutation(mutationList: MutationRecord[]) {
+        const affected = new Set<BxSelectElement>();
+
+        for (const mutation of mutationList) {
+            if (mutation.type !== 'childList' && mutation.type !== 'attributes') continue;
+
+            const $target = mutation.target as Element;
+            if (!$target || !$target.closest) continue;
+
+            const $wrapper = $target.closest('.bx-select') as BxSelectElement | null;
+            if ($wrapper && $wrapper.$select && $wrapper.$select.contains($target)) {
+                affected.add($wrapper);
+            }
+        }
+
+        for (const $wrapper of affected) {
+            $wrapper.visibleIndex = $wrapper.$select.selectedIndex;
+            $wrapper.optionsList = Array.from($wrapper.$select.querySelectorAll<HTMLOptionElement>('option'));
+
+            BxSelectElement.resetIndicators.call($wrapper);
+            BxSelectElement.render.call($wrapper);
+        }
+    }
+
     static create($select: HTMLSelectElement, forceFriendly=false): BxSelectElement {
         const isControllerFriendly = forceFriendly || getGlobalPref(GlobalPref.UI_CONTROLLER_FRIENDLY);
 
@@ -122,24 +158,7 @@ export class BxSelectElement extends HTMLSelectElement {
         }
 
         $select.addEventListener('input', BxSelectElement.render.bind(self));
-
-        const observer = new MutationObserver((mutationList, observer) => {
-            mutationList.forEach(mutation => {
-                if (mutation.type === 'childList' || mutation.type === 'attributes') {
-                    self.visibleIndex = $select.selectedIndex;
-                    self.optionsList = Array.from($select.querySelectorAll<HTMLOptionElement>('option'));
-
-                    BxSelectElement.resetIndicators.call(self);
-                    BxSelectElement.render.call(self);
-                }
-            });
-        });
-
-        observer.observe($select, {
-            subtree: true,
-            childList: true,
-            attributes: true,
-        });
+        BxSelectElement.ensureObserver();
 
         self.append(
             $select,


### PR DESCRIPTION
## What

Every `BxSelectElement.create()` was attaching its **own `MutationObserver`** to the `<select>` (subtree + childList + attributes). With many selects in the settings dialogs that's one observer per select, all watching the same document.

Now a **single static observer** watches `document.documentElement` once and routes mutations to the affected `.bx-select` wrappers via `closest()`, only re-rendering selects whose own subtree actually changed (deduplicated with a `Set` per mutation batch). All other re-render triggers (input, change, value setter) are unchanged.

Also removes a leftover **`debugger;`** statement in `Translations.downloadTranslations()`'s catch block — a no-op in production except pausing the script when the DevTools are open.

## Why it's safe

- Same events observed (childList + subtree + attributes) — just on one shared observer instead of N.
- Routing via `closest('.bx-select')` targets the same wrappers; the per-select re-render logic is untouched.
- The `Set` dedup prevents double re-renders within a mutation batch (strictly fewer renders than before).

## Files

- `src/web-components/bx-select.ts` — static global observer + `ensureObserver()` + delegated `onMutation`
- `src/utils/translation.ts` — `debugger;` removed from the catch block

## Note

`translation.ts` is also touched by the open PRs #908 (mkb zoom), #938 (local co-op) and #468 (record) — all in different regions (the debugger line is ours). Happy to rebase if any of them merges first.