### PR TITLE
fix(controller): guard btnHome against gamepads without a buttons array

### DIFF
--- a/src/modules/patcher/patches/src/poll-gamepad.ts
+++ b/src/modules/patcher/patches/src/poll-gamepad.ts
@@ -21,7 +21,10 @@ if (window.BX_EXPOSED.disableGamepadPolling) {
 
 const currentGamepad = $gamepadVar$;
 
-const btnHome = currentGamepad.buttons[16];
+// Guard against gamepads that report no buttons array (see #991):
+// `buttons[16]` on `undefined` throws and silently kills the whole polling
+// loop — controller input then stops working until a reload.
+const btnHome = currentGamepad.buttons?.[16];
 // Controller shortcuts
 if (btnHome) {
     if (!self.bxHomeStates) {


### PR DESCRIPTION
Fixes the crash class reported in **#991**: controller input silently stops working — `pollGamepad` throws `Cannot read properties of undefined (reading 'pressed')`.

## Root cause

`poll-gamepad` reads the Home button state on every poll:

```ts
const btnHome = currentGamepad.buttons[16];
```

Gamepad objects are **not guaranteed** to expose a `buttons` array at every poll (observed on a GameSir G7 SE). When the array is missing, `buttons[16]` throws, the exception kills the whole polling loop and controller input **silently stops working** until a reload — the exact symptom in #991.

## Fix

```ts
const btnHome = currentGamepad.buttons?.[16];
```

- When `buttons` is missing, `btnHome` is `undefined` → the controller-shortcuts block becomes a no-op.
- The rest of the poll (gamepad input delivery, button mapping) keeps running.
- **Zero behavioral change** for gamepads that report buttons normally.

## Verification

- Build: exit 0 (eslint + TS gate).
- Bundle: guarded access present, unguarded `buttons[16]` gone.
- Minimal diff: 1 file, +3/−1.

@redphx — happy to adjust if you'd rather guard `currentGamepad` itself too.