### PR TITLE
fix: per-player controller remapping broken for identical controllers in local co-op

### DIFF
--- a/src/modules/controller-shortcut.ts
+++ b/src/modules/controller-shortcut.ts
@@ -1,4 +1,7 @@
 import { GamepadKey } from "@enums/gamepad";
+import { StreamPref } from "@enums/pref-keys";
+import { getStreamPref } from "@/utils/pref-utils";
+import { getGamepadKey } from "@/utils/gamepad";
 import { ShortcutHandler } from "@/utils/shortcut-handler";
 
 
@@ -12,7 +15,8 @@ export class ControllerShortcut {
     }
 
     static handle(gamepad: Gamepad): boolean {
-        const controllerSettings = window.BX_STREAM_SETTINGS.controllers[gamepad.id];
+        const gamepadKey = getGamepadKey(gamepad, getStreamPref(StreamPref.LOCAL_CO_OP_ENABLED));
+        const controllerSettings = window.BX_STREAM_SETTINGS.controllers[gamepadKey];
         if (!controllerSettings) {
             return false;
         }

--- a/src/modules/patcher/patches/src/controller-customization.ts
+++ b/src/modules/patcher/patches/src/controller-customization.ts
@@ -10,8 +10,9 @@ const shareButtonPressed = currentGamepad.buttons[17]?.pressed;
 let shareButtonHandled = false;
 
 const xCloudGamepad: XcloudGamepad = $xCloudGamepadVar$;
-if (currentGamepad.id in window.BX_STREAM_SETTINGS.controllers) {
-    const controller = window.BX_STREAM_SETTINGS.controllers[currentGamepad.id];
+const gamepadKey = window.BX_EXPOSED.localCoOpEnabled ? `${currentGamepad.id}::${currentGamepad.index}` : currentGamepad.id;
+if (gamepadKey in window.BX_STREAM_SETTINGS.controllers) {
+    const controller = window.BX_STREAM_SETTINGS.controllers[gamepadKey];
     if (controller?.customization) {
         const MIN_RANGE = 0.1;
 

--- a/src/modules/patcher/patches/src/vibration-adjust.ts
+++ b/src/modules/patcher/patches/src/vibration-adjust.ts
@@ -8,7 +8,8 @@ declare const e: {
 };
 
 if (e?.gamepad?.connected) {
-    const gamepadSettings = window.BX_STREAM_SETTINGS.controllers[e.gamepad.id];
+    const gamepadKey = window.BX_EXPOSED.localCoOpEnabled ? `${e.gamepad.id}::${e.gamepad.index}` : e.gamepad.id;
+    const gamepadSettings = window.BX_STREAM_SETTINGS.controllers[gamepadKey];
     if (gamepadSettings?.customization) {
         const intensity = gamepadSettings.customization.vibrationIntensity;
 

--- a/src/modules/ui/dialog/profile-manger/controller-customizations-manager-dialog.ts
+++ b/src/modules/ui/dialog/profile-manger/controller-customizations-manager-dialog.ts
@@ -28,6 +28,7 @@ export class ControllerCustomizationsManagerDialog extends BaseProfileManagerDia
     private $leftStickDeadzone!: BxDualNumberStepper;
     private $rightStickDeadzone!: BxDualNumberStepper;
     private $btnDetect!: HTMLButtonElement;
+    private $hintMapping!: HTMLElement;
 
     private selectsMap: PartialRecord<GamepadKey, HTMLSelectElement> = {};
     private selectsOrder: GamepadKey[] = [];
@@ -160,6 +161,9 @@ export class ControllerCustomizationsManagerDialog extends BaseProfileManagerDia
                 },
             }),
 
+            // Mapping hint
+            this.$hintMapping = CE('div', { class: 'bx-settings-dialog-note' }, 'ⓘ ' + t('controller-customization-hint')),
+
             // Mapping
             $rows,
 
@@ -287,8 +291,9 @@ export class ControllerCustomizationsManagerDialog extends BaseProfileManagerDia
         const isDefaultPreset = id <= 0;
         this.updateButtonStates();
 
-        // Show/hide Detect button
+        // Show/hide Detect button and hint
         $btnDetect.classList.toggle('bx-gone', isDefaultPreset);
+        this.$hintMapping.classList.toggle('bx-gone', isDefaultPreset);
 
         // Set mappings
         let buttonIndex: unknown;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -38,6 +38,7 @@ declare global {
         BX_EXPOSED: typeof BxExposed & Partial<{
             shouldShowSensorControls: boolean;
             stopTakRendering: boolean;
+            localCoOpEnabled: boolean;
             dialogRoutes: {
                 closeAll: () => void;
             };

--- a/src/utils/bx-exposed.ts
+++ b/src/utils/bx-exposed.ts
@@ -5,14 +5,14 @@ import { deepClone, STATES } from "@utils/global";
 import { BxLogger } from "./bx-logger";
 import { BX_FLAGS } from "./bx-flags";
 import { NavigationDialogManager } from "@/modules/ui/dialog/navigation-dialog";
-import { GlobalPref } from "@/enums/pref-keys";
+import { GlobalPref, StreamPref } from "@/enums/pref-keys";
 import { GamePassCloudGallery } from "@/enums/game-pass-gallery";
 import { TouchController } from "@/modules/touch-controller";
 import { NativeMkbMode, TouchControllerMode } from "@/enums/pref-values";
 import { Patcher, type PatchPage } from "@/modules/patcher/patcher";
 import { BxEventBus } from "./bx-event-bus";
 import { FeatureGates } from "./feature-gates";
-import { getGlobalPref } from "./pref-utils";
+import { getGlobalPref, getStreamPref } from "./pref-utils";
 import { LocalCoOpManager } from "./local-co-op-manager";
 
 export enum SupportedInputType {
@@ -212,6 +212,10 @@ export const BxExposed = {
     },
 
     disableGamepadPolling: false,
+
+    get localCoOpEnabled(): boolean {
+        return getStreamPref(StreamPref.LOCAL_CO_OP_ENABLED);
+    },
 
     backButtonPressed: () => {
         const navigationDialogManager = NavigationDialogManager.getInstance();

--- a/src/utils/gamepad.ts
+++ b/src/utils/gamepad.ts
@@ -41,17 +41,34 @@ export function showGamepadToast(gamepad: Gamepad) {
     Toast.show(text, status, { instant: false });
 }
 
+export function getGamepadKey(gamepad: Gamepad, isCoOp: boolean): string {
+    return isCoOp ? `${gamepad.id}::${gamepad.index}` : gamepad.id;
+}
+
 export function simplifyGamepadName(name: string) {
-    return name.replace(/\s+\(.*Vendor: ([0-9a-f]{4}) Product: ([0-9a-f]{4})\)$/, ' ($1-$2)');
+    let playerIndex = -1;
+    let gamepadId = name;
+
+    const match = name.match(/^(.*)::(\d+)$/);
+    if (match) {
+        gamepadId = match[1];
+        playerIndex = parseInt(match[2]);
+    }
+
+    gamepadId = gamepadId.replace(/\s+\(.*Vendor: ([0-9a-f]{4}) Product: ([0-9a-f]{4})\)$/, ' ($1-$2)');
+
+    return playerIndex >= 0 ? `🎮 #${playerIndex + 1} - ${gamepadId}` : gamepadId;
 }
 
 export function getUniqueGamepadNames() {
     const gamepads = window.navigator.getGamepads();
     const names: string[] = [];
+    const isCoOp = getStreamPref(StreamPref.LOCAL_CO_OP_ENABLED);
 
     for (const gamepad of gamepads) {
         if (gamepad?.connected && gamepad.id !== VIRTUAL_GAMEPAD_ID) {
-            !names.includes(gamepad.id) && names.push(gamepad.id);
+            const key = getGamepadKey(gamepad, isCoOp);
+            !names.includes(key) && names.push(key);
         }
     }
 

--- a/src/utils/settings-storages/stream-settings-storage.ts
+++ b/src/utils/settings-storages/stream-settings-storage.ts
@@ -494,6 +494,15 @@ export class StreamSettingsStorage extends BaseSettingsStorage<StreamPref> {
     getControllerSetting(gamepadId: string): ControllerSetting {
         const controllerSettings = this.getSetting(StreamPref.CONTROLLER_SETTINGS);
         let controllerSetting = controllerSettings[gamepadId];
+
+        // Fallback to the base gamepad.id preset when a co-op composite key (id::index) isn't stored yet
+        if (!controllerSetting) {
+            const baseGamepadId = gamepadId.replace(/::\d+$/, '');
+            if (baseGamepadId !== gamepadId) {
+                controllerSetting = controllerSettings[baseGamepadId];
+            }
+        }
+
         if (!controllerSetting) {
             controllerSetting = {} as ControllerSetting;
         }

--- a/src/utils/stream-settings.ts
+++ b/src/utils/stream-settings.ts
@@ -4,7 +4,7 @@ import type { ControllerCustomizationConvertedPresetData, ControllerCustomizatio
 import { STATES } from "./global";
 import { DeviceVibrationMode } from "@/enums/pref-values";
 import { VIRTUAL_GAMEPAD_ID } from "@/modules/mkb/mkb-handler";
-import { hasGamepad, toXcloudGamepadKey } from "./gamepad";
+import { getGamepadKey, hasGamepad, toXcloudGamepadKey } from "./gamepad";
 import { MkbMappingPresetsTable } from "./local-db/mkb-mapping-presets-table";
 import { GamepadKey } from "@/enums/gamepad";
 import { MkbPresetKey, MouseConstant } from "@/enums/mkb";
@@ -58,6 +58,7 @@ export class StreamSettings {
         const mappingTable = ControllerCustomizationsTable.getInstance();
 
         const gamepads = window.navigator.getGamepads();
+        const isCoOp = getStreamPref(StreamPref.LOCAL_CO_OP_ENABLED);
         for (const gamepad of gamepads) {
             if (!gamepad?.connected) {
                 continue;
@@ -68,7 +69,8 @@ export class StreamSettings {
                 continue;
             }
 
-            const controllerSetting = STORAGE.Stream.getControllerSetting(gamepad.id);
+            const gamepadKey = getGamepadKey(gamepad, isCoOp);
+            const controllerSetting = STORAGE.Stream.getControllerSetting(gamepadKey);
 
             // Shortcuts
             const shortcutsPreset = await shortcutsTable.getPreset(controllerSetting.shortcutPresetId);
@@ -78,7 +80,7 @@ export class StreamSettings {
             const customizationPreset = await mappingTable.getPreset(controllerSetting.customizationPresetId);
             const customizationData = StreamSettings.convertControllerCustomization(customizationPreset?.data);
 
-            controllers[gamepad.id] = {
+            controllers[gamepadKey] = {
                 shortcuts: shortcutsMapping,
                 customization: customizationData,
             }

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -89,6 +89,7 @@ const Texts = {
     "contrast": "Contrast",
     "controller": "Controller",
     "controller-customization": "Controller customization",
+    "controller-customization-hint": "Leave buttons as --- to pass them through unchanged",
     "controller-customization-input-latency-note": "May slightly increase input latency",
     "controller-friendly-ui": "Controller-friendly UI",
     "controller-shortcuts": "Controller shortcuts",


### PR DESCRIPTION

When two players use identical controllers (same model, same gamepad.id), their button remapping and shortcut presets were shared instead of being independent. Fixed by keying settings on gamepad.id::gamepad.index when local co-op is enabled.

Useful for games like FC 26 where two players using identical controllers may prefer different button layouts (e.g. alternate vs classic).

- Add getGamepadKey() utility and update simplifyGamepadName() to display player index
- Expose localCoOpEnabled via BX_EXPOSED getter (derived from stream pref)
- Fallback to base gamepad.id preset when composite key has no stored settings
- Update controller-customization, vibration-adjust patches and controller-shortcut module
- Add hint text in customization dialog to clarify --- means pass-through